### PR TITLE
Adding missed timeout config

### DIFF
--- a/tools/stratos-installer/config/all/repository/conf/autoscaler.xml
+++ b/tools/stratos-installer/config/all/repository/conf/autoscaler.xml
@@ -35,5 +35,8 @@
 			<port>SM_LISTEN_PORT</port>
             		<clientTimeout>300000</clientTimeout>
 		</stratosManager>
+		<member>
+			<expiryTimeout>900000</expiryTimeout>
+		</member>
 	</autoscaler>
 </configuration>


### PR DESCRIPTION
autoscaler.xml inside apache-stratos-4.0.0.zip gets replaced by this xml which is missing the timeout configuration.
