### PR TITLE
Fixing STRATOS-762

### DIFF
--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/dto/Cartridge.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/dto/Cartridge.java
@@ -52,6 +52,8 @@ public class Cartridge implements Comparable<Cartridge> {
 
     //LB cluster id
     private String lbClusterId;
+    
+    private String clusterId;
 
 	private String[] accessURLs;
 	private PortMapping[] portMappings;
@@ -293,4 +295,13 @@ public class Cartridge implements Comparable<Cartridge> {
 	public void setServiceGroup(String serviceGroup) {
 		this.serviceGroup = serviceGroup;
 	}
+
+	public String getClusterId() {
+		return clusterId;
+	}
+
+	public void setClusterId(String clusterId) {
+		this.clusterId = clusterId;
+	}
+
 }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/services/ServiceUtils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/services/ServiceUtils.java
@@ -877,6 +877,7 @@ public class ServiceUtils {
                 cartridge.setLbClusterId(subscription.getLbClusterId());
             }
 
+            cartridge.setClusterId(subscription.getClusterDomain());
             cartridge.setStatus(subscription.getSubscriptionStatus());
             cartridge.setPortMappings(subscription.getCartridgeInfo()
                     .getPortMappings());


### PR DESCRIPTION
This is to retrieve the cluster ID. This would help contract the URL in the case where LB is not present. Our dev setup doesn't have a LB.
