### PR TITLE
Merging kubernetes integration with user Management changes

### DIFF
--- a/components/org.apache.stratos.autoscaler/src/main/resources/META-INF/component.xml
+++ b/components/org.apache.stratos.autoscaler/src/main/resources/META-INF/component.xml
@@ -35,4 +35,42 @@
             <class>org.apache.stratos.autoscaler.partition.deployers.PartitionDeployer</class>
         </deployer>-->
     </deployers>
+    <ManagementPermissions>
+        <ManagementPermission>
+            <DisplayName>Autoscaling Policy</DisplayName>
+            <ResourceId>/permission/admin/manage/add/autoscalingPolicy</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Deployment Policy</DisplayName>
+            <ResourceId>/permission/admin/manage/add/deploymentPolicy</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Partition</DisplayName>
+            <ResourceId>/permission/admin/manage/add/partition</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>View</DisplayName>
+            <ResourceId>/permission/admin/manage/view/</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Autoscaling Policy</DisplayName>
+            <ResourceId>/permission/admin/manage/view/autoscalingPolicy</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Deployment Policy</DisplayName>
+            <ResourceId>/permission/admin/manage/view/deploymentPolicy</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Partition</DisplayName>
+            <ResourceId>/permission/admin/manage/view/partition</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Kubernetes</DisplayName>
+            <ResourceId>/permission/admin/manage/add/kubernetes</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Kubernetes</DisplayName>
+            <ResourceId>/permission/admin/manage/view/kubernetes</ResourceId>
+        </ManagementPermission>
+    </ManagementPermissions>
 </component>

--- a/components/org.apache.stratos.autoscaler/src/main/resources/META-INF/services.xml
+++ b/components/org.apache.stratos.autoscaler/src/main/resources/META-INF/services.xml
@@ -27,5 +27,76 @@
 		<messageReceiver mep="http://www.w3.org/ns/wsdl/in-only" class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
 		<messageReceiver mep="http://www.w3.org/ns/wsdl/in-out" class="org.apache.axis2.rpc.receivers.RPCMessageReceiver"/>
 	</messageReceivers>
+        <operation name="addAutoScalingPolicy">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/autoscalingPolicy</parameter>
+        </operation>
+
+        <operation name="addDeploymentPolicy">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/deploymentPolicy</parameter>
+        </operation>
+
+        <operation name="addPartition">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/partition</parameter>
+        </operation>
+
+        <operation name="getAllAutoScalingPolicy">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/autoscalingPolicy</parameter>
+        </operation>
+
+        <operation name="getAllDeploymentPolicies">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/deploymentPolicy</parameter>
+        </operation>
+
+        <operation name="getAllAvailablePartitions">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/partition</parameter>
+        </operation>
+
+        <operation name="getAutoscalingPolicy">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/autoscalingPolicy</parameter>
+        </operation>
+
+        <operation name="getDeploymentPolicy">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/deploymentPolicy</parameter>
+        </operation>
+
+        <operation name="getAllAvailablePartitions">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/partition</parameter>
+        </operation>
+
+        <operation name="addKubernetesGroup">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/kubernetes</parameter>
+        </operation>
+
+        <operation name="addKubernetesHost">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/kubernetes</parameter>
+        </operation>
+
+        <operation name="updateKubernetesHost">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/kubernetes</parameter>
+        </operation>
+
+        <operation name="updateKubernetesMaster">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/kubernetes</parameter>
+        </operation>
+
+        <operation name="removeKubernetesGroup">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/kubernetes</parameter>
+        </operation>
+
+        <operation name="removeKubernetesHost">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/kubernetes</parameter>
+        </operation>
+
+        <operation name="getAllKubernetesGroups">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/kubernetes</parameter>
+        </operation>
+
+        <operation name="getHostsForKubernetesGroup">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/kubernetes</parameter>
+        </operation>
+
+        <operation name="getMasterForKubernetesGroup">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/kubernetes</parameter>
+        </operation>
     </service>
 </serviceGroup> 

--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/StratosApplication.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/StratosApplication.java
@@ -42,10 +42,12 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.stratos.cli.commands.ActivateTenantCommand;
 import org.apache.stratos.cli.commands.AddTenantCommand;
+import org.apache.stratos.cli.commands.AddUserCommand;
 import org.apache.stratos.cli.commands.AutoscalePolicyCommand;
 import org.apache.stratos.cli.commands.AutoscalingPolicyDeploymentCommand;
 import org.apache.stratos.cli.commands.CartridgeDeploymentCommand;
 import org.apache.stratos.cli.commands.DeactivateTenantCommand;
+import org.apache.stratos.cli.commands.DeleteUserCommand;
 import org.apache.stratos.cli.commands.DeployServiceDeploymentCommand;
 import org.apache.stratos.cli.commands.DeploymentPolicyCommand;
 import org.apache.stratos.cli.commands.DeploymentPolicyDeploymentCommand;
@@ -133,6 +135,12 @@ public class StratosApplication extends CommandLineApplication<StratosCommandCon
 		commands.put(command.getName(), command);
 
         command = new AddTenantCommand();
+        commands.put(command.getName(), command);
+
+        command = new AddUserCommand();
+        commands.put(command.getName(), command);
+
+        command = new DeleteUserCommand();
         commands.put(command.getName(), command);
 
         //command = new DeleteTenantCommand();

--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/beans/UserInfoBean.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/beans/UserInfoBean.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.cli.beans;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class UserInfoBean {
+
+    private String userName;
+    private String credential;
+    private String role;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String profileName;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getCredential() {
+        return credential;
+    }
+
+    public void setCredential(String credential) {
+        this.credential = credential;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getProfileName() {
+        return profileName;
+    }
+
+    public void setProfileName(String profileName) {
+        this.profileName = profileName;
+    }
+
+}

--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/commands/AddUserCommand.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/commands/AddUserCommand.java
@@ -1,0 +1,191 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+
+ *  http://www.apache.org/licenses/LICENSE-2.0
+
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.stratos.cli.commands;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.stratos.cli.Command;
+import org.apache.stratos.cli.RestCommandLineService;
+import org.apache.stratos.cli.StratosCommandContext;
+import org.apache.stratos.cli.exception.CommandException;
+import org.apache.stratos.cli.utils.CliConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AddUserCommand implements Command<StratosCommandContext> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AddUserCommand.class);
+
+    private final Options options;
+
+    public AddUserCommand(){
+        options = constructOptions();
+    }
+
+    private Options constructOptions() {
+        final Options options = new Options();
+
+        Option usernameOption = new Option(CliConstants.USERNAME_OPTION, CliConstants.USERNAME_LONG_OPTION, true,
+                "User name");
+        usernameOption.setArgName("userName");
+        options.addOption(usernameOption);
+
+        Option passwordOption = new Option(CliConstants.PASSWORD_OPTION, CliConstants.PASSWORD_LONG_OPTION, true,
+                                           "User credential");
+        passwordOption.setArgName("credential");
+        options.addOption(passwordOption);
+
+        Option roleOption = new Option(CliConstants.ROLE_NAME_OPTION, CliConstants.ROLE_NAME_LONG_OPTION, true,
+                                           "User Role");
+        roleOption.setArgName("role");
+        options.addOption(roleOption);
+
+        Option fistnameOption = new Option(CliConstants.FIRST_NAME_OPTION, CliConstants.FIRST_NAME_LONG_OPTION, true,
+                "User first name");
+        fistnameOption.setArgName("firstName");
+        options.addOption(fistnameOption);
+
+        Option lastnameOption = new Option(CliConstants.LAST_NAME_OPTION, CliConstants.LAST_NAME_LONG_OPTION, true,
+                "User last name");
+        lastnameOption.setArgName("lastName");
+        options.addOption(lastnameOption);
+
+        Option emailOption = new Option(CliConstants.EMAIL_OPTION, CliConstants.EMAIL_LONG_OPTION, true,
+                                        "User email");
+        emailOption.setArgName("email");
+        options.addOption(emailOption);
+
+        Option profileNameOption = new Option(CliConstants.PROFILE_NAME_OPTION, CliConstants.PROFILE_NAME_LONG_OPTION, true,
+                "Tenant domain");
+        profileNameOption.setArgName("profileName");
+        options.addOption(profileNameOption);
+
+        return options;
+    }
+
+    public String getName() {
+        return CliConstants.ADD_USER;
+    }
+
+    public String getDescription() {
+        return "Add new user";
+    }
+
+    public String getArgumentSyntax() {
+        return null;
+    }
+
+    public int execute(StratosCommandContext context, String[] args) throws CommandException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Executing {} command...", getName());
+        }
+
+        if (args != null && args.length > 0) {
+            String userName= null;
+            String credential= null;
+            String role= null;
+            String firstName= null;
+            String lastName= null;
+            String email= null;
+            String profileName= null;
+
+            final CommandLineParser parser = new GnuParser();
+            CommandLine commandLine;
+
+            try {
+                commandLine = parser.parse(options, args);
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Add tenant");
+                }
+
+                if (commandLine.hasOption(CliConstants.USERNAME_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Username option is passed");
+                    }
+                    userName = commandLine.getOptionValue(CliConstants.USERNAME_OPTION);
+                }
+                if (commandLine.hasOption(CliConstants.PASSWORD_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Credential option is passed");
+                    }
+                    credential = commandLine.getOptionValue(CliConstants.PASSWORD_OPTION);
+                }
+                if (commandLine.hasOption(CliConstants.ROLE_NAME_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Role option is passed");
+                    }
+                    role = commandLine.getOptionValue(CliConstants.ROLE_NAME_OPTION);
+                }
+                if (commandLine.hasOption(CliConstants.FIRST_NAME_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("First name option is passed");
+                    }
+                    firstName = commandLine.getOptionValue(CliConstants.FIRST_NAME_OPTION);
+                }
+                if (commandLine.hasOption(CliConstants.LAST_NAME_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Last name option is passed");
+                    }
+                    lastName = commandLine.getOptionValue(CliConstants.LAST_NAME_OPTION);
+                }
+                if (commandLine.hasOption(CliConstants.EMAIL_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Email option is passed");
+                    }
+                    email = commandLine.getOptionValue(CliConstants.EMAIL_OPTION);
+                }
+                if (commandLine.hasOption(CliConstants.PROFILE_NAME_OPTION)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Profile name option is passed");
+                    }
+                    profileName = commandLine.getOptionValue(CliConstants.PROFILE_NAME_OPTION);
+                }
+
+
+                if (userName == null || credential == null || role == null || firstName == null || lastName == null || email == null) {
+                    System.out.println("usage: " + getName() + " [-u <user name>] [-p <credential>] [-r <role>] [-f <first name>] [-l <last name>] [-e <email>] [-pr <profile name>]");
+                    return CliConstants.BAD_ARGS_CODE;
+                }
+
+                RestCommandLineService.getInstance().addUser(userName, credential, role, firstName, lastName, email, profileName);
+                return CliConstants.SUCCESSFUL_CODE;
+
+            } catch (ParseException e) {
+                if (logger.isErrorEnabled()) {
+                    logger.error("Error parsing arguments", e);
+                }
+                System.out.println(e.getMessage());
+                return CliConstants.BAD_ARGS_CODE;
+            }
+
+        } else {
+            context.getStratosApplication().printUsage(getName());
+            return CliConstants.BAD_ARGS_CODE;
+        }
+    }
+
+    public Options getOptions() {
+        return options;
+    }
+}

--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/commands/DeleteUserCommand.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/commands/DeleteUserCommand.java
@@ -1,0 +1,70 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+
+ *  http://www.apache.org/licenses/LICENSE-2.0
+
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.stratos.cli.commands;
+
+import org.apache.commons.cli.Options;
+import org.apache.stratos.cli.Command;
+import org.apache.stratos.cli.RestCommandLineService;
+import org.apache.stratos.cli.StratosCommandContext;
+import org.apache.stratos.cli.exception.CommandException;
+import org.apache.stratos.cli.utils.CliConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteUserCommand implements Command<StratosCommandContext> {
+    private static final Logger logger = LoggerFactory.getLogger(DeleteUserCommand.class);
+
+    @Override
+    public String getName() {
+        return CliConstants.DELETE_USER;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Delete User";
+    }
+
+    @Override
+    public String getArgumentSyntax() {
+        return "[UserName]";
+    }
+
+    @Override
+    public Options getOptions() {
+        return null;
+    }
+
+    @Override
+    public int execute(StratosCommandContext context, String[] args) throws CommandException {
+        if (logger.isDebugEnabled()) {
+			logger.debug("Executing {} command...", getName());
+		}
+		if (args != null && args.length == 1) {
+			String id = args[0];
+			if (logger.isDebugEnabled()) {
+				logger.debug("Getting delete user info {}", id);
+			}
+			RestCommandLineService.getInstance().deleteUser(id);
+			return CliConstants.SUCCESSFUL_CODE;
+		} else {
+			context.getStratosApplication().printUsage(getName());
+			return CliConstants.BAD_ARGS_CODE;
+		}
+    }
+}

--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/utils/CliConstants.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/utils/CliConstants.java
@@ -85,6 +85,11 @@ public class CliConstants {
     public static final String ADD_TENANT = "create-tenant";
 
     /**
+     * Add user
+     */
+    public static final String ADD_USER = "create-user";
+
+    /**
      * Cartridge deployment
      */
     public static final String CARTRIDGE_DEPLOYMENT = "deploy-cartridge";
@@ -168,6 +173,10 @@ public class CliConstants {
      * Delete tenant
      */
     public static final String DELETE_TENANT = "delete-tenant";
+    /**
+     * Delete user
+     */
+    public static final String DELETE_USER= "delete-user";
     /**
      * Deactivate tenant
      */
@@ -274,6 +283,13 @@ public class CliConstants {
     public static final String ACTIVE_OPTION = "a";
     public static final String ACTIVE_LONG_OPTION = "active";
 
+    // Add User options
+    public static final String ROLE_NAME_OPTION = "r";
+    public static final String ROLE_NAME_LONG_OPTION = "role-name";
+
+    public static final String PROFILE_NAME_OPTION = "pr";
+    public static final String PROFILE_NAME_LONG_OPTION = "profile-name";
+
     // Deployment options
     public static final String RESOURCE_PATH = "p";
     public static final String RESOURCE_PATH_LONG_OPTION = "resource-path";
@@ -282,5 +298,6 @@ public class CliConstants {
     public static final String RESPONSE_AUTHORIZATION_FAIL = "403";
     public static final String RESPONSE_NO_CONTENT = "204";
     public static final String RESPONSE_OK = "200";
+    public static final String RESPONSE_CREATED = "201";
     public static final String RESPONSE_BAD_REQUEST = "400";
 }

--- a/components/org.apache.stratos.cloud.controller/src/main/resources/META-INF/component.xml
+++ b/components/org.apache.stratos.cloud.controller/src/main/resources/META-INF/component.xml
@@ -34,4 +34,26 @@
             <class>org.apache.stratos.cloud.controller.deployers.ServiceDeployer</class>
         </deployer-->
     </deployers>
+    <ManagementPermissions>
+        <ManagementPermission>
+            <DisplayName>Cartridge Definition</DisplayName>
+            <ResourceId>/permission/admin/manage/add/cartridgeDefinition</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Service</DisplayName>
+            <ResourceId>/permission/admin/manage/add/service</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>View</DisplayName>
+            <ResourceId>/permission/admin/manage/view</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Service</DisplayName>
+            <ResourceId>/permission/admin/manage/view/service</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Cartridge</DisplayName>
+            <ResourceId>/permission/admin/manage/view/cartridge</ResourceId>
+        </ManagementPermission>
+    </ManagementPermissions>
 </component>

--- a/components/org.apache.stratos.cloud.controller/src/main/resources/META-INF/services.xml
+++ b/components/org.apache.stratos.cloud.controller/src/main/resources/META-INF/services.xml
@@ -27,5 +27,23 @@
         <messageReceiver mep="http://www.w3.org/ns/wsdl/in-only" class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         <messageReceiver mep="http://www.w3.org/ns/wsdl/in-out" class="org.apache.axis2.rpc.receivers.RPCMessageReceiver"/>
     </messageReceivers>
+        <operation name="deployCartridgeDefinition">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/cartridgeDefinition</parameter>
+        </operation>
+        <operation name="undeployCartridgeDefinition">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/cartridgeDefinition</parameter>
+        </operation>
+        <operation name="getRegisteredCartridges">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/cartridge</parameter>
+        </operation>
+        <operation name="getCartridgeInfo">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/view/cartridge</parameter>
+        </operation>
+        <operation name="registerService">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/service</parameter>
+        </operation>
+        <operation name="unregisterService">
+            <parameter name="AuthorizationAction" locked="true">/permission/admin/manage/add/service</parameter>
+        </operation>
     </service>
 </serviceGroup> 

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/internal/ADCManagementServerComponent.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/internal/ADCManagementServerComponent.java
@@ -21,11 +21,13 @@ package org.apache.stratos.manager.internal;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.stratos.manager.listener.InstanceStatusListener;
+import org.apache.stratos.manager.listener.TenantUserRoleCreator;
 import org.apache.stratos.manager.publisher.TenantEventPublisher;
 import org.apache.stratos.manager.publisher.TenantSynchronizerTaskScheduler;
 import org.apache.stratos.manager.retriever.DataInsertionAndRetrievalManager;
 import org.apache.stratos.manager.topology.receiver.StratosManagerTopologyEventReceiver;
 import org.apache.stratos.manager.utils.CartridgeConfigFileReader;
+import org.apache.stratos.manager.utils.UserRoleCreator;
 import org.apache.stratos.messaging.broker.publish.EventPublisherPool;
 import org.apache.stratos.messaging.broker.subscribe.TopicSubscriber;
 import org.apache.stratos.messaging.util.Constants;
@@ -89,6 +91,14 @@ public class ADCManagementServerComponent {
             subscriber.setMessageListener(new InstanceStatusListener());
             Thread tsubscriber = new Thread(subscriber);
 			tsubscriber.start();
+
+            //Create a Tenant-User Role at server start-up
+            UserRoleCreator.CreateTenantUserRole();
+
+            TenantUserRoleCreator tenantUserRoleCreator = new TenantUserRoleCreator();
+            componentContext.getBundleContext().registerService(
+                    org.apache.stratos.common.listeners.TenantMgtListener.class.getName(),
+                    tenantUserRoleCreator, null);
 
             //initializing the topology event subscriber
             /*TopicSubscriber topologyTopicSubscriber = new TopicSubscriber(Constants.TOPOLOGY_TOPIC);

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/listener/TenantUserRoleCreator.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/listener/TenantUserRoleCreator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.manager.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.stratos.common.beans.TenantInfoBean;
+import org.apache.stratos.common.exception.StratosException;
+import org.apache.stratos.common.listeners.TenantMgtListener;
+import org.apache.stratos.manager.internal.DataHolder;
+import org.apache.stratos.manager.utils.CartridgeConstants;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.user.api.Permission;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.mgt.UserMgtConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+
+public class TenantUserRoleCreator implements TenantMgtListener {
+
+    private transient static final Log log = LogFactory.getLog(TenantUserRoleCreator.class);
+    private static String role = "Internal/user";
+
+    /**
+     * Create an 'user' role at tenant creation time
+     * @param tenantInfo
+     * @throws StratosException
+     */
+    @Override
+    public void onTenantCreate(TenantInfoBean tenantInfo) throws StratosException {
+
+            try {
+
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+                carbonContext.setTenantDomain(tenantInfo.getTenantDomain());
+                carbonContext.setTenantId(tenantInfo.getTenantId());
+
+                UserRealm userRealm = DataHolder.getRealmService().getTenantUserRealm(tenantInfo.getTenantId());
+                UserStoreManager manager = userRealm.getUserStoreManager();
+
+                if (!manager.isExistingRole(role)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Creating new role: " + role);
+                    }
+
+                    Permission[] TenantUserPermissions = new Permission[]{  new Permission(CartridgeConstants.Permissions.VIEW_AUTOSCALING_POLICY, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_DEPLOYMENT_POLICY, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_CARTRIDGE, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_SERVICE, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_SUBSCRIPTION, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_DOMAIN, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_CLUSTER, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_INSTANCE, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.VIEW_KUBERNETES, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.ADD_GIT_SYNC, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.ADD_SUBSCRIPTION, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.ADD_DOMAIN, UserMgtConstants.EXECUTE_ACTION),
+                                                                            new Permission(CartridgeConstants.Permissions.REST_LOGIN, UserMgtConstants.EXECUTE_ACTION),
+                    };
+
+                    String[] userList = new String[]{};
+                    manager.addRole(role, userList, TenantUserPermissions);
+                }
+
+            } catch (UserStoreException e) {
+                log.error("Error while creating the role: " + role + " - " +
+                          e.getMessage());
+            } finally {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
+
+        }
+
+
+    @Override
+    public void onTenantUpdate(TenantInfoBean tenantInfo) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantDelete(int tenantId) {
+
+    }
+
+    @Override
+    public void onTenantRename(int tenantId, String oldDomainName, String newDomainName)
+            throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantInitialActivation(int tenantId) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantActivation(int tenantId) throws StratosException {
+
+    }
+
+    @Override
+    public void onTenantDeactivation(int tenantId) throws StratosException {
+
+    }
+
+    @Override
+    public void onSubscriptionPlanChange(int tenentId, String oldPlan, String newPlan)
+            throws StratosException {
+
+    }
+
+    @Override
+    public int getListenerOrder() {
+        return 0;
+    }
+}

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/user/mgt/StratosUserManager.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/user/mgt/StratosUserManager.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.manager.user.mgt;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.stratos.manager.internal.DataHolder;
+import org.apache.stratos.manager.user.mgt.beans.UserInfoBean;
+import org.apache.stratos.manager.user.mgt.exception.UserManagementException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class StratosUserManager {
+
+    private transient static final Log log = LogFactory.getLog(StratosUserManager.class);
+    private UserStoreManager userStoreManager;
+
+
+    public StratosUserManager(UserStoreManager userStoreManager) {
+        this.userStoreManager = userStoreManager;
+
+    }
+
+    /**
+     * Add a user to the user store
+     *
+     * @param userInfoBean
+     * @throws UserStoreException
+     */
+    public void addUser(UserInfoBean userInfoBean) throws UserManagementException {
+
+        try {
+
+            if (!userStoreManager.isExistingUser(userInfoBean.getUserName())) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Creating new User: " + userInfoBean.getUserName());
+                }
+            }
+            String[] roles = new String[1];
+            roles[0] = userInfoBean.getRole();
+            Map<String, String> claims = new HashMap<String, String>();
+
+            claims.put(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS, userInfoBean.getEmail());
+            claims.put(UserCoreConstants.ClaimTypeURIs.GIVEN_NAME, userInfoBean.getFirstName());
+            claims.put(UserCoreConstants.ClaimTypeURIs.SURNAME, userInfoBean.getLastName());
+            userStoreManager.addUser(userInfoBean.getUserName(), userInfoBean.getCredential(), roles, claims, userInfoBean.getProfileName());
+
+        } catch (UserStoreException e) {
+            log.error(e.getMessage(), e);
+            throw new UserManagementException(e.getMessage(), e);
+        }
+
+    }
+
+    /**
+     * Delete the user with the given user name
+     *
+     * @param userName The user name
+     * @throws UserStoreException
+     */
+    public void deleteUser(String userName) throws UserManagementException {
+
+        try {
+            userStoreManager.deleteUser(userName);
+        } catch (UserStoreException e) {
+            log.error(e.getMessage(), e);
+            throw new UserManagementException(e.getMessage(), e);
+        }
+    }
+
+
+    /**
+     * Updates the user info
+     *
+     * @param userInfoBean
+     */
+    public void updateUser(UserInfoBean userInfoBean) throws UserManagementException {
+
+        try {
+            if (userStoreManager.isExistingUser(userInfoBean.getUserName())) {
+                String[] newRoles = new String[1];
+                newRoles[0] = userInfoBean.getRole();
+
+                //String[] rolesToDelete = new String[1];
+                ArrayList<String> rolesToDelete = new ArrayList<String>();
+                String[] currentRolesList = userStoreManager.getRoleListOfUser(userInfoBean.getUserName());
+                for(String role: currentRolesList){
+                    if(!role.equals("Internal/everyone")){
+                        rolesToDelete.add(role);
+                    }
+                }
+                String[] rolesToDeleteArray = new String[rolesToDelete.size()];
+                Map<String, String> claims = new HashMap<String, String>();
+
+                claims.put(UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS, userInfoBean.getEmail());
+                claims.put(UserCoreConstants.ClaimTypeURIs.GIVEN_NAME, userInfoBean.getFirstName());
+                claims.put(UserCoreConstants.ClaimTypeURIs.SURNAME, userInfoBean.getLastName());
+
+                userStoreManager.updateRoleListOfUser(userInfoBean.getUserName(), rolesToDelete.toArray(rolesToDeleteArray), newRoles);
+                userStoreManager.setUserClaimValue(userInfoBean.getUserName(),UserCoreConstants.ClaimTypeURIs.EMAIL_ADDRESS, userInfoBean.getEmail(),userInfoBean.getProfileName());
+                userStoreManager.setUserClaimValue(userInfoBean.getUserName(),UserCoreConstants.ClaimTypeURIs.GIVEN_NAME, userInfoBean.getFirstName(),userInfoBean.getProfileName());
+                userStoreManager.setUserClaimValue(userInfoBean.getUserName(),UserCoreConstants.ClaimTypeURIs.SURNAME, userInfoBean.getLastName(),userInfoBean.getProfileName());
+                userStoreManager.updateCredentialByAdmin(userInfoBean.getUserName(), userInfoBean.getCredential());
+
+            }
+        } catch (UserStoreException e) {
+            log.error(e.getMessage(), e);
+            throw new UserManagementException(e.getMessage(), e);
+        }
+
+    }
+
+}

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/user/mgt/beans/UserInfoBean.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/user/mgt/beans/UserInfoBean.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.manager.user.mgt.beans;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class UserInfoBean {
+
+    private String userName;
+    private String credential;
+    private String role;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String profileName;
+
+    public UserInfoBean(){}
+
+    public UserInfoBean(UserInfoBean userInfoBean) {
+        this.userName = userInfoBean.getUserName();
+        this.credential = userInfoBean.getCredential();
+        this.role = userInfoBean.getRole();
+        this.firstName = userInfoBean.getFirstName();
+        this.lastName = userInfoBean.getLastName();
+        this.email = userInfoBean.getEmail();
+        this.profileName = userInfoBean.getProfileName();
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getCredential() {
+        return credential;
+    }
+
+    public void setCredential(String credential) {
+        this.credential = credential;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getProfileName() {
+        return profileName;
+    }
+
+    public void setProfileName(String profileName) {
+        this.profileName = profileName;
+    }
+
+}

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/user/mgt/exception/UserManagementException.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/user/mgt/exception/UserManagementException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.manager.user.mgt.exception;
+
+
+public class UserManagementException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public UserManagementException() {
+        }
+
+        public UserManagementException(String message) {
+            super(message);
+        }
+
+        public UserManagementException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public UserManagementException(Throwable cause) {
+            super(cause);
+        }
+    }

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/utils/CartridgeConstants.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/utils/CartridgeConstants.java
@@ -105,4 +105,21 @@ public class CartridgeConstants {
 		public static final String ACTUAL_HOST = "actual.host";
 		public static final String HOSTINFO = "hostinfo/";
 	}
+
+    public static final class Permissions {
+        public static final String ADD_SUBSCRIPTION = "/permission/admin/manage/add/subscription";
+        public static final String REST_LOGIN = "/permission/admin/restlogin";
+        public static final String ADD_GIT_SYNC = "/permission/admin/manage/add/sync";
+        public static final String ADD_DOMAIN = "/permission/admin/manage/add/domain";
+        public static final String VIEW_AUTOSCALING_POLICY = "/permission/admin/manage/view/autoscalingPolicy";
+        public static final String VIEW_DEPLOYMENT_POLICY = "/permission/admin/manage/view/deploymentPolicy";
+        public static final String VIEW_SUBSCRIPTION = "/permission/admin/manage/view/subscription";
+        public static final String VIEW_CARTRIDGE = "/permission/admin/manage/view/cartridge";
+        public static final String VIEW_SERVICE = "/permission/admin/manage/view/service";
+        public static final String VIEW_DOMAIN = "/permission/admin/manage/view/domain";
+        public static final String VIEW_CLUSTER = "/permission/admin/manage/view/cluster";
+        public static final String VIEW_INSTANCE = "/permission/admin/manage/view/instance";
+        public static final String VIEW_KUBERNETES = "/permission/admin/manage/view/kubernetes";
+        public static final String VIEW_PARTITION = "/permission/admin/manage/view/partition";
+    }
 }

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/utils/UserRoleCreator.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/utils/UserRoleCreator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.manager.utils;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.stratos.manager.internal.DataHolder;
+import org.wso2.carbon.user.api.Permission;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.mgt.UserMgtConstants;
+
+public class UserRoleCreator {
+
+    private transient static final Log log = LogFactory.getLog(UserRoleCreator.class);
+    private static String role = "Internal/user";
+
+    /**
+     * Creating a Tenant User Carbon Role at Server Start-up
+     */
+    public static void CreateTenantUserRole() {
+
+        try {
+
+            RealmService realmService = DataHolder.getRealmService();
+            UserRealm realm = realmService.getBootstrapRealm();
+            UserStoreManager manager = realm.getUserStoreManager();
+
+            if (!manager.isExistingRole(role)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Creating new role: " + role);
+                }
+                Permission[] TenantUserPermissions = new Permission[]{  new Permission(CartridgeConstants.Permissions.VIEW_AUTOSCALING_POLICY, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_DEPLOYMENT_POLICY, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_CARTRIDGE, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_SERVICE, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_SUBSCRIPTION, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_DOMAIN, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_CLUSTER, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_INSTANCE, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.VIEW_KUBERNETES, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.ADD_GIT_SYNC, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.ADD_SUBSCRIPTION, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.ADD_DOMAIN, UserMgtConstants.EXECUTE_ACTION),
+                                                                        new Permission(CartridgeConstants.Permissions.REST_LOGIN, UserMgtConstants.EXECUTE_ACTION),
+                };
+
+                String[] userList = new String[]{};
+                manager.addRole(role, userList, TenantUserPermissions);
+            }
+
+        } catch (UserStoreException e) {
+            log.error("Error while creating the role: " + role + " - " +
+                      e.getMessage());
+        }
+
+    }
+}

--- a/components/org.apache.stratos.manager/src/main/resources/META-INF/component.xml
+++ b/components/org.apache.stratos.manager/src/main/resources/META-INF/component.xml
@@ -1,0 +1,62 @@
+<!-- 
+  #  Licensed to the Apache Software Foundation (ASF) under one
+  #  or more contributor license agreements.  See the NOTICE file
+  #  distributed with this work for additional information
+  #  regarding copyright ownership.  The ASF licenses this file
+  #  to you under the Apache License, Version 2.0 (the
+  #  "License"); you may not use this file except in compliance
+  #  with the License.  You may obtain a copy of the License at
+  #  
+  #  http://www.apache.org/licenses/LICENSE-2.0
+  #  
+  #  Unless required by applicable law or agreed to in writing,
+  #  software distributed under the License is distributed on an
+  #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  #  KIND, either express or implied.  See the License for the
+  #  specific language governing permissions and limitations
+  #  under the License.
+  -->
+<component xmlns="http://products.wso2.org/carbon">
+    <ManagementPermissions>
+        <ManagementPermission>
+            <DisplayName>Subscription</DisplayName>
+            <ResourceId>/permission/admin/manage/add/subscription</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>View</DisplayName>
+            <ResourceId>/permission/admin/manage/view</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Subscription</DisplayName>
+            <ResourceId>/permission/admin/manage/view/subscription</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Users</DisplayName>
+            <ResourceId>/permission/admin/manage/add/users</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Git Sync</DisplayName>
+            <ResourceId>/permission/admin/manage/add/sync</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>REST Login</DisplayName>
+            <ResourceId>/permission/admin/restlogin</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Domain</DisplayName>
+            <ResourceId>/permission/admin/manage/add/domain</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Domain</DisplayName>
+            <ResourceId>/permission/admin/manage/view/domain</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Cluster</DisplayName>
+            <ResourceId>/permission/admin/manage/view/cluster</ResourceId>
+        </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Instance</DisplayName>
+            <ResourceId>/permission/admin/manage/view/instance</ResourceId>
+        </ManagementPermission>
+    </ManagementPermissions>
+</component>

--- a/components/org.apache.stratos.register.ui/src/main/resources/web/tenant-register/select_domain.jsp
+++ b/components/org.apache.stratos.register.ui/src/main/resources/web/tenant-register/select_domain.jsp
@@ -60,24 +60,24 @@
         }
     }
 
-    jQuery(document).ready(
-                          function() {
-                              jQuery.ajax({
-                                  type: 'POST',
-                                  url: 'get_package_info_ajaxprocessor.jsp',
-                                  dataType: 'json',
-                                  data: 'plan=0',
-                                  async: false,
-                                  success: function(data) {
-                                      packageInfo = data;
-                                  },
-                                  error:function (xhr, ajaxOptions, thrownError) {
-                                      CARBON.showErrorDialog('Could not get package information.');
-                                  }
-                              });
-
-                          }
-            );
+//    jQuery(document).ready(
+//                          function() {
+//                              jQuery.ajax({
+//                                  type: 'POST',
+//                                  url: 'get_package_info_ajaxprocessor.jsp',
+//                                  dataType: 'json',
+//                                  data: 'plan=0',
+//                                  async: false,
+//                                  success: function(data) {
+//                                      packageInfo = data;
+//                                  },
+//                                  error:function (xhr, ajaxOptions, thrownError) {
+//                                      CARBON.showErrorDialog('Could not get package information.');
+//                                  }
+//                              });
+//
+//                          }
+//            );
 </script>
 
 

--- a/components/org.apache.stratos.register.ui/src/main/resources/web/tenant-register/select_usage_plan.jsp
+++ b/components/org.apache.stratos.register.ui/src/main/resources/web/tenant-register/select_usage_plan.jsp
@@ -51,21 +51,21 @@
     var packageInfo;
     function showRentalMessage() {
 
-        if (packageInfo == null) {
-            jQuery.ajax({
-                type: 'POST',
-                url: 'get_package_info_ajaxprocessor.jsp',
-                dataType: 'json',
-                data: 'plan=0',
-                async: false,
-                success: function(data) {
-                    packageInfo = data;
-                },
-                error:function (xhr, ajaxOptions, thrownError) {
-                    CARBON.showErrorDialog('Could not get package information.');
-                }
-            });
-        }
+//        if (packageInfo == null) {
+//            jQuery.ajax({
+//                type: 'POST',
+//                url: 'get_package_info_ajaxprocessor.jsp',
+//                dataType: 'json',
+//                data: 'plan=0',
+//                async: false,
+//                success: function(data) {
+//                    packageInfo = data;
+//                },
+//                error:function (xhr, ajaxOptions, thrownError) {
+//                    CARBON.showErrorDialog('Could not get package information.');
+//                }
+//            });
+//        }
 
         var plan = document.getElementById('selectedUsagePlan').
                 options[document.getElementById('selectedUsagePlan').selectedIndex].value;
@@ -129,19 +129,19 @@
 
     jQuery(document).ready(
                           function() {
-                              jQuery.ajax({
-                                  type: 'POST',
-                                  url: 'get_package_info_ajaxprocessor.jsp',
-                                  dataType: 'json',
-                                  data: 'plan=0',
-                                  async: false,
-                                  success: function(data) {
-                                      packageInfo = data;
-                                  },
-                                  error:function (xhr, ajaxOptions, thrownError) {
-                                      CARBON.showErrorDialog('Could not get package information.');
-                                  }
-                              });
+//                              jQuery.ajax({
+//                                  type: 'POST',
+//                                  url: 'get_package_info_ajaxprocessor.jsp',
+//                                  dataType: 'json',
+//                                  data: 'plan=0',
+//                                  async: false,
+//                                  success: function(data) {
+//                                      packageInfo = data;
+//                                  },
+//                                  error:function (xhr, ajaxOptions, thrownError) {
+//                                      CARBON.showErrorDialog('Could not get package information.');
+//                                  }
+//                              });
 
                               var charge;
                               var name;

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/services/StratosAdmin.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/services/StratosAdmin.java
@@ -30,6 +30,8 @@ import org.apache.stratos.manager.dto.SubscriptionInfo;
 import org.apache.stratos.manager.exception.DomainMappingExistsException;
 import org.apache.stratos.manager.exception.ServiceDoesNotExistException;
 import org.apache.stratos.manager.subscription.CartridgeSubscription;
+import org.apache.stratos.manager.subscription.SubscriptionDomain;
+import org.apache.stratos.manager.user.mgt.beans.UserInfoBean;
 import org.apache.stratos.rest.endpoint.ServiceHolder;
 import org.apache.stratos.rest.endpoint.Utils;
 import org.apache.stratos.rest.endpoint.annotation.AuthorizationAction;
@@ -46,6 +48,7 @@ import org.apache.stratos.rest.endpoint.bean.kubernetes.KubernetesGroup;
 import org.apache.stratos.rest.endpoint.bean.kubernetes.KubernetesHost;
 import org.apache.stratos.rest.endpoint.bean.kubernetes.KubernetesMaster;
 import org.apache.stratos.rest.endpoint.bean.repositoryNotificationInfoBean.Payload;
+import org.apache.stratos.rest.endpoint.bean.repositoryNotificationInfoBean.Repository;
 import org.apache.stratos.rest.endpoint.bean.subscription.domain.SubscriptionDomainBean;
 import org.apache.stratos.rest.endpoint.bean.topology.Cluster;
 import org.apache.stratos.rest.endpoint.exception.KubernetesGroupDoesNotExistException;
@@ -60,7 +63,8 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreManager;
-import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.Tenant;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -90,8 +94,8 @@ public class StratosAdmin extends AbstractAdmin {
 
     @POST
     @Path("/init")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public StratosAdminResponse initialize()
+    @AuthorizationAction("/permission/admin/restlogin")
+    public StratosAdminResponse initialize ()
             throws RestAPIException {
 
 
@@ -99,7 +103,6 @@ public class StratosAdmin extends AbstractAdmin {
         stratosAdminResponse.setMessage("Successfully logged in");
         return stratosAdminResponse;
     }
-
     /*
     This method gets called by the client who are interested in using session mechanism to authenticate themselves in
     subsequent calls. This method call get authenticated by the basic authenticator.
@@ -110,13 +113,13 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cookie")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getCookie() {
+    @AuthorizationAction("/permission/admin/restlogin")
+    public Response getCookie(){
         HttpSession httpSession = httpServletRequest.getSession(true);//create session if not found
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-        httpSession.setAttribute("userName", carbonContext.getUsername());
-        httpSession.setAttribute("tenantDomain", carbonContext.getTenantDomain());
-        httpSession.setAttribute("tenantId", carbonContext.getTenantId());
+        httpSession.setAttribute("userName",carbonContext.getUsername());
+        httpSession.setAttribute("tenantDomain",carbonContext.getTenantDomain());
+        httpSession.setAttribute("tenantId",carbonContext.getTenantId());
 
         String sessionId = httpSession.getId();
         return Response.ok().header("WWW-Authenticate", "Basic").type(MediaType.APPLICATION_JSON).
@@ -127,14 +130,13 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/definition/")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
+    @AuthorizationAction("/permission/admin/manage/add/cartridgeDefinition")
     public Response deployCartridgeDefinition(CartridgeDefinitionBean cartridgeDefinitionBean)
             throws RestAPIException {
 
         ServiceUtils.deployCartridge(cartridgeDefinitionBean, getConfigContext(), getUsername(),
                 getTenantDomain());
-        URI url = uriInfo.getAbsolutePathBuilder().path(cartridgeDefinitionBean.type).build();
+        URI url =  uriInfo.getAbsolutePathBuilder().path(cartridgeDefinitionBean.type).build();
         return Response.created(url).build();
 
     }
@@ -143,9 +145,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/definition/{cartridgeType}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response unDeployCartridgeDefinition(@PathParam("cartridgeType") String cartridgeType) throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/add/cartridgeDefinition")
+    public Response unDeployCartridgeDefinition (@PathParam("cartridgeType") String cartridgeType) throws RestAPIException {
 
         ServiceUtils.undeployCartridge(cartridgeType);
         return Response.noContent().build();
@@ -155,120 +156,25 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/policy/deployment/partition")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response deployPartition(Partition partition)
+    @AuthorizationAction("/permission/admin/manage/add/partition")
+    public Response deployPartition (Partition partition)
             throws RestAPIException {
 
         ServiceUtils.deployPartition(partition);
-        URI url = uriInfo.getAbsolutePathBuilder().path(partition.id).build();
+        URI url =  uriInfo.getAbsolutePathBuilder().path(partition.id).build();
         return Response.created(url).build();
     }
-
-    @POST
-    @Path("/kubernetes/deploy/group")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response deployKubernetesGroup(KubernetesGroup kubernetesGroup)
-            throws RestAPIException {
-
-        ServiceUtils.deployKubernetesGroup(kubernetesGroup);
-        URI url = uriInfo.getAbsolutePathBuilder().path(kubernetesGroup.getGroupId()).build();
-        return Response.created(url).build();
-    }
-
-    @POST
-    @Path("/kubernetes/deploy/host/{kubernetesGroupId}")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response deployKubernetesHost(@PathParam("kubernetesGroupId") String kubernetesGroupId, KubernetesHost kubernetesHost)
-            throws RestAPIException {
-
-        ServiceUtils.deployKubernetesHost(kubernetesGroupId, kubernetesHost);
-        URI url = uriInfo.getAbsolutePathBuilder().path(kubernetesHost.getHostId()).build();
-        return Response.created(url).build();
-    }
-
-    @PUT
-    @Path("/kubernetes/update/master")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response updateKubernetesMaster(KubernetesMaster kubernetesMaster)
-            throws RestAPIException {
-
-        ServiceUtils.updateKubernetesMaster(kubernetesMaster);
-        URI url = uriInfo.getAbsolutePathBuilder().path(kubernetesMaster.getHostId()).build();
-        return Response.created(url).build();
-    }
-
-    @GET
-    @Path("/kubernetes/group")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getKubernetesGroups() throws RestAPIException {
-        return Response.ok().entity(ServiceUtils.getAvailableKubernetesGroups()).build();
-    }
-
-
-    @GET
-    @Path("/kubernetes/group/{kubernetesGroupId}")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getKubernetesGroup(@PathParam("kubernetesGroupId") String kubernetesGroupId) throws RestAPIException {
-        return Response.ok().entity(ServiceUtils.getKubernetesGroup(kubernetesGroupId)).build();
-    }
-
-
-    @DELETE
-    @Path("/kubernetes/group/{kubernetesGroupId}")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response unDeployKubernetesGroup(@PathParam("kubernetesGroupId") String kubernetesGroupId) throws RestAPIException {
-        try {
-            ServiceUtils.undeployKubernetesGroup(kubernetesGroupId);
-        } catch (KubernetesGroupDoesNotExistException e) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
-        return Response.noContent().build();
-    }
-
-    @DELETE
-    @Path("/kubernetes/group/{kubernetesHostId}")
-    @Produces("application/json")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response unDeployKubernetesHost(@PathParam("kubernetesHostId") String kubernetesHostId) throws RestAPIException {
-        try {
-            ServiceUtils.undeployKubernetesHost(kubernetesHostId);
-        } catch (KubernetesHostDoesNotExistException e) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
-        return Response.noContent().build();
-    }
-
 
     @POST
     @Path("/policy/autoscale")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response deployAutoscalingPolicyDefintion(AutoscalePolicy autoscalePolicy)
+    @AuthorizationAction("/permission/admin/manage/add/autoscalingPolicy")
+    public Response deployAutoscalingPolicyDefintion (AutoscalePolicy autoscalePolicy)
             throws RestAPIException {
 
         ServiceUtils.deployAutoscalingPolicy(autoscalePolicy);
-        URI url = uriInfo.getAbsolutePathBuilder().path(autoscalePolicy.getId()).build();
+        URI url =  uriInfo.getAbsolutePathBuilder().path(autoscalePolicy.getId()).build();
         return Response.created(url).build();
     }
 
@@ -276,13 +182,12 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/policy/deployment")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response deployDeploymentPolicyDefinition(DeploymentPolicy deploymentPolicy)
+    @AuthorizationAction("/permission/admin/manage/add/deploymentPolicy")
+    public Response deployDeploymentPolicyDefinition (DeploymentPolicy deploymentPolicy)
             throws RestAPIException {
 
         ServiceUtils.deployDeploymentPolicy(deploymentPolicy);
-        URI url = uriInfo.getAbsolutePathBuilder().path(deploymentPolicy.id).build();
+        URI url =  uriInfo.getAbsolutePathBuilder().path(deploymentPolicy.id).build();
         return Response.created(url).build();
     }
 
@@ -290,8 +195,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/partition")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getPartitions() throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/partition")
+    public Response getPartitions () throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getAvailablePartitions()).build();
     }
 
@@ -299,8 +204,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/partition/{partitionId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getPartition(@PathParam("partitionId") String partitionId) throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/partition")
+    public Response getPartition (@PathParam("partitionId") String partitionId) throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getPartition(partitionId)).build();
     }
 
@@ -308,8 +213,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/partition/group/{deploymentPolicyId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getPartitionGroups(@PathParam("deploymentPolicyId") String deploymentPolicyId)
+    @AuthorizationAction("/permission/admin/manage/view/partition")
+    public Response getPartitionGroups (@PathParam("deploymentPolicyId") String deploymentPolicyId)
             throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getPartitionGroups(deploymentPolicyId)).build();
     }
@@ -318,18 +223,18 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/partition/{deploymentPolicyId}/{partitionGroupId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getPartitions(@PathParam("deploymentPolicyId") String deploymentPolicyId,
-                                  @PathParam("partitionGroupId") String partitionGroupId) throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/partition")
+    public Response getPartitions (@PathParam("deploymentPolicyId") String deploymentPolicyId,
+                                       @PathParam("partitionGroupId") String partitionGroupId) throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getPartitionsOfGroup(deploymentPolicyId, partitionGroupId)).build();
     }
-
+    
     @GET
     @Path("/partition/{deploymentPolicyId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getPartitionsOfPolicy(@PathParam("deploymentPolicyId") String deploymentPolicyId)
+    @AuthorizationAction("/permission/admin/manage/view/partition")
+    public Response getPartitionsOfPolicy (@PathParam("deploymentPolicyId") String deploymentPolicyId)
             throws RestAPIException {
 
         return Response.ok().entity(ServiceUtils.getPartitionsOfDeploymentPolicy(deploymentPolicyId)).build();
@@ -339,8 +244,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/policy/autoscale")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getAutoscalePolicies() throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/autoscalingPolicy")
+    public Response getAutoscalePolicies () throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getAutoScalePolicies()).build();
     }
 
@@ -348,8 +253,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/policy/autoscale/{autoscalePolicyId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getAutoscalePolicies(@PathParam("autoscalePolicyId") String autoscalePolicyId)
+    @AuthorizationAction("/permission/admin/manage/view/autoscalingPolicy")
+    public Response getAutoscalePolicies (@PathParam("autoscalePolicyId") String autoscalePolicyId)
             throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getAutoScalePolicy(autoscalePolicyId)).build();
     }
@@ -358,8 +263,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/policy/deployment")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getDeploymentPolicies() throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/deploymentPolicy")
+    public Response getDeploymentPolicies () throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getDeploymentPolicies()).build();
     }
 
@@ -367,8 +272,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/policy/deployment/{deploymentPolicyId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getDeploymentPolicies(@PathParam("deploymentPolicyId") String deploymentPolicyId)
+    @AuthorizationAction("/permission/admin/manage/view/deploymentPolicy")
+    public Response getDeploymentPolicies (@PathParam("deploymentPolicyId") String deploymentPolicyId)
             throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getDeploymentPolicy(deploymentPolicyId)).build();
     }
@@ -377,8 +282,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("{cartridgeType}/policy/deployment")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getValidDeploymentPolicies(@PathParam("cartridgeType") String cartridgeType)
+    @AuthorizationAction("/permission/admin/manage/view/deploymentPolicy")
+    public Response getValidDeploymentPolicies (@PathParam("cartridgeType") String cartridgeType)
             throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getDeploymentPolicies(cartridgeType)).build();
     }
@@ -387,7 +292,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/tenanted/list")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getAvailableMultiTenantCartridges() throws RestAPIException {
         List<Cartridge> cartridges = ServiceUtils.getAvailableCartridges(null, true, getConfigContext());
         ResponseBuilder rb = Response.ok();
@@ -399,7 +304,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/list")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getAvailableSingleTenantCartridges() throws RestAPIException {
         List<Cartridge> cartridges = ServiceUtils.getAvailableCartridges(null, false, getConfigContext());
         ResponseBuilder rb = Response.ok();
@@ -411,7 +316,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/available/list")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getAvailableCartridges() throws RestAPIException {
         List<Cartridge> cartridges = ServiceUtils.getAvailableCartridges(null, null, getConfigContext());
         ResponseBuilder rb = Response.ok();
@@ -423,9 +328,9 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/list/subscribed")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getSubscribedCartridges() throws RestAPIException {
-        List<Cartridge> cartridgeList = ServiceUtils.getSubscriptions(null, null, getConfigContext());
+        List<Cartridge> cartridgeList = ServiceUtils.getSubscriptions(null,null, getConfigContext());
         // Following is very important when working with axis2
         ResponseBuilder rb = Response.ok();
         rb.entity(cartridgeList.isEmpty() ? new Cartridge[0] : cartridgeList.toArray(new Cartridge[cartridgeList.size()]));
@@ -436,7 +341,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/list/subscribed/group/{serviceGroup}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getSubscribedCartridgesForServiceGroup(@PathParam("serviceGroup") String serviceGroup) throws RestAPIException {
         List<Cartridge> cartridgeList = ServiceUtils.getSubscriptions(null, serviceGroup, getConfigContext());
         // Following is very important when working with axis2
@@ -444,12 +349,12 @@ public class StratosAdmin extends AbstractAdmin {
         rb.entity(cartridgeList.isEmpty() ? new Cartridge[0] : cartridgeList.toArray(new Cartridge[cartridgeList.size()]));
         return rb.build();
     }
-
+    
     @GET
     @Path("/cartridge/info/{subscriptionAlias}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getCartridgeInfo(@PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException {
         ResponseBuilder rb = Response.ok();
         rb.entity(ServiceUtils.getSubscription(subscriptionAlias, getConfigContext()));
@@ -460,9 +365,9 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/available/info/{cartridgeType}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getAvailableSingleTenantCartridgeInfo(@PathParam("cartridgeType") String cartridgeType)
-            throws RestAPIException {
+                                            throws RestAPIException {
         ResponseBuilder rb = Response.ok();
         rb.entity(ServiceUtils.getAvailableCartridgeInfo(cartridgeType, null, getConfigContext()));
         return rb.build();
@@ -472,9 +377,9 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/lb")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cartridge")
     public Response getAvailableLbCartridges() throws RestAPIException {
-        List<Cartridge> lbCartridges = ServiceUtils.getAvailableLbCartridges(false, getConfigContext());
+    	List<Cartridge> lbCartridges = ServiceUtils.getAvailableLbCartridges(false, getConfigContext());
         return Response.ok().entity(lbCartridges.isEmpty() ? new Cartridge[0] : lbCartridges.toArray(new Cartridge[lbCartridges.size()])).build();
     }
 
@@ -482,9 +387,9 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/active/{cartridgeType}/{subscriptionAlias}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/instance")
     public Response getActiveInstances(@PathParam("cartridgeType") String cartridgeType,
-                                       @PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException {
+                              @PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException {
         ResponseBuilder rb = Response.ok();
         rb.entity(ServiceUtils.getActiveInstances(cartridgeType, subscriptionAlias, getConfigContext()));
         return rb.build();
@@ -494,13 +399,13 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cartridge/subscribe")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/add/subscription")
     public Response subscribe(CartridgeInfoBean cartridgeInfoBean) throws RestAPIException {
 
-        SubscriptionInfo subscriptionInfo = ServiceUtils.subscribe(cartridgeInfoBean,
-                getConfigContext(),
-                getUsername(),
-                getTenantDomain());
+        SubscriptionInfo subscriptionInfo= ServiceUtils.subscribe(cartridgeInfoBean,
+                                                                  getConfigContext(),
+                                                                  getUsername(),
+                                                                  getTenantDomain());
         return Response.ok(subscriptionInfo).build();
     }
 
@@ -508,7 +413,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cluster/")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cluster")
     public Response getClustersForTenant() throws RestAPIException {
         return Response.ok().entity(ServiceUtils.getClustersForTenant(getConfigContext())).build();
     }
@@ -517,19 +422,19 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cluster/{cartridgeType}/")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cluster")
     public Response getClusters(@PathParam("cartridgeType") String cartridgeType) throws RestAPIException {
 
         ResponseBuilder rb = Response.ok();
         rb.entity(ServiceUtils.getClustersForTenantAndCartridgeType(getConfigContext(), cartridgeType));
         return rb.build();
     }
-
+    
     @GET
     @Path("/cluster/service/{cartridgeType}/")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cluster")
     public Response getServiceClusters(@PathParam("cartridgeType") String cartridgeType) throws RestAPIException {
         ResponseBuilder rb = Response.ok();
         rb.entity(ServiceUtils.getClustersForTenantAndCartridgeType(getConfigContext(), cartridgeType));
@@ -540,37 +445,37 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/cluster/{cartridgeType}/{subscriptionAlias}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cluster")
     public Response getCluster(@PathParam("cartridgeType") String cartridgeType,
-                               @PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException, RestAPIException {
+                              @PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException, RestAPIException {
         ResponseBuilder rb = Response.ok();
         rb.entity(ServiceUtils.getCluster(cartridgeType, subscriptionAlias, getConfigContext()));
         return rb.build();
     }
-
+    
     @GET
     @Path("/cluster/clusterId/{clusterId}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cluster")
     public Response getCluster(@PathParam("clusterId") String clusterId) throws RestAPIException {
-        Cluster cluster = null;
-        if (log.isDebugEnabled()) {
-            log.debug("Finding cluster for [id]: " + clusterId);
-        }
+    	Cluster cluster = null;
+    	if(log.isDebugEnabled()) {
+    		log.debug("Finding cluster for [id]: "+clusterId);
+    	}
         Cluster[] clusters = ServiceUtils.getClustersForTenant(getConfigContext());
-        if (log.isDebugEnabled()) {
-            log.debug("Clusters retrieved from backend for cluster [id]: " + clusterId);
-            for (Cluster c : clusters) {
-                log.debug(c + "\n");
-            }
-        }
+        if(log.isDebugEnabled()) {
+        	log.debug("Clusters retrieved from backend for cluster [id]: "+clusterId);
+    		for (Cluster c : clusters) {
+				log.debug(c+"\n");
+			}
+    	}
         for (Cluster clusterObj : clusters) {
-            if (clusterObj.clusterId.equals(clusterId)) {
-                cluster = clusterObj;
-                break;
-            }
-        }
+			if (clusterObj.clusterId.equals(clusterId)){
+				cluster = clusterObj;
+				break;
+			}
+		}
         return Response.ok().entity(cluster).build();
     }
 
@@ -587,7 +492,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/tenant")
     @Consumes("application/json")
     @Produces("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/protected/manage/modify/tenants")
     @SuperTenantService(true)
     public Response addTenant(TenantInfoBean tenantInfoBean) throws RestAPIException {
         try {
@@ -623,7 +528,7 @@ public class StratosAdmin extends AbstractAdmin {
         int tenantId = 0; //TODO verify whether this is the correct approach (isSkeleton)
         try {
             tenantId = persistor.persistTenant(tenant, false, tenantInfoBean.getSuccessKey(),
-                    tenantInfoBean.getOriginatedService(), false);
+                    tenantInfoBean.getOriginatedService(),false);
         } catch (Exception e) {
             String msg = "Error in persisting tenant " + tenantDomain;
             log.error(msg, e);
@@ -664,23 +569,23 @@ public class StratosAdmin extends AbstractAdmin {
             throw new RestAPIException(msg);
         }
 
-        URI url = uriInfo.getAbsolutePathBuilder().path(tenant.getDomain()).build();
+        URI url =  uriInfo.getAbsolutePathBuilder().path(tenant.getDomain()).build();
         return Response.created(url).build();
     }
 
     @PUT
     @Path("/tenant")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/protected/manage/modify/tenants")
     @SuperTenantService(true)
     public Response updateTenant(TenantInfoBean tenantInfoBean) throws RestAPIException {
 
         try {
             updateExistingTenant(tenantInfoBean);
 
-        } catch (TenantNotFoundException ex) {
+        } catch(TenantNotFoundException ex){
             Response.status(Response.Status.NOT_FOUND).build();
-        } catch (Exception e) {
+        }catch (Exception e) {
             String msg = "Error in updating tenant " + tenantInfoBean.getTenantDomain();
             log.error(msg, e);
             throw new RestAPIException(msg);
@@ -717,7 +622,7 @@ public class StratosAdmin extends AbstractAdmin {
             String msg = "Error in retrieving the tenant id for the tenant domain: " +
                     tenantDomain + ".";
             log.error(msg, e);
-            throw new TenantNotFoundException(msg, e);
+            throw new TenantNotFoundException(msg,e);
         }
 
         // filling the first and last name values
@@ -827,7 +732,7 @@ public class StratosAdmin extends AbstractAdmin {
         }
     }
 
-    private TenantInfoBean getTenantForDomain(String tenantDomain) throws Exception {
+    private TenantInfoBean getTenantForDomain (String tenantDomain) throws Exception {
 
         TenantManager tenantManager = ServiceHolder.getTenantManager();
 
@@ -861,9 +766,9 @@ public class StratosAdmin extends AbstractAdmin {
         String activePlan = "";
         //TODO: usage plan using billing service
 
-        if (activePlan != null && activePlan.trim().length() > 0) {
+        if(activePlan != null && activePlan.trim().length() > 0){
             bean.setUsagePlan(activePlan);
-        } else {
+        }else{
             bean.setUsagePlan("");
         }
 
@@ -927,7 +832,7 @@ public class StratosAdmin extends AbstractAdmin {
     @Produces("application/json")
     @AuthorizationAction("/permission/protected/manage/monitor/tenants")
     @SuperTenantService(true)
-    public TenantInfoBean[] retrievePartialSearchTenants(@PathParam("domain") String domain) throws RestAPIException {
+    public TenantInfoBean[] retrievePartialSearchTenants(@PathParam("domain")String domain) throws RestAPIException {
         List<TenantInfoBean> tenantList = null;
         try {
             tenantList = searchPartialTenantsDomains(domain);
@@ -942,7 +847,7 @@ public class StratosAdmin extends AbstractAdmin {
     @POST
     @Path("tenant/activate/{tenantDomain}")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/protected/manage/modify/tenants")
     @SuperTenantService(true)
     public Response activateTenant(@PathParam("tenantDomain") String tenantDomain) throws RestAPIException {
         TenantManager tenantManager = ServiceHolder.getTenantManager();
@@ -955,16 +860,13 @@ public class StratosAdmin extends AbstractAdmin {
                     + ".";
             log.error(msg, e);
             throw new RestAPIException(msg, e);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-
-            throw new RestAPIException(e);
         }
 
         try {
             TenantMgtUtil.activateTenant(tenantDomain, tenantManager, tenantId);
 
         } catch (Exception e) {
-            throw new RestAPIException(e);
+            throw new RestAPIException( e);
         }
 
         //Notify tenant activation all listeners
@@ -982,7 +884,7 @@ public class StratosAdmin extends AbstractAdmin {
     @POST
     @Path("tenant/availability/{tenantDomain}")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/protected/manage/modify/tenants")
     @SuperTenantService(true)
     public Response isDomainAvailable(@PathParam("tenantDomain") String tenantDomain) throws RestAPIException {
         boolean available;
@@ -999,7 +901,7 @@ public class StratosAdmin extends AbstractAdmin {
     @POST
     @Path("tenant/deactivate/{tenantDomain}")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/protected/manage/modify/tenants")
     @SuperTenantService(true)
     public Response deactivateTenant(@PathParam("tenantDomain") String tenantDomain) throws RestAPIException {
 
@@ -1015,14 +917,12 @@ public class StratosAdmin extends AbstractAdmin {
             log.error(msg, e);
             throw new RestAPIException(msg, e);
 
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new RestAPIException(e);
         }
 
         try {
             TenantMgtUtil.deactivateTenant(tenantDomain, tenantManager, tenantId);
         } catch (Exception e) {
-            throw new RestAPIException(e);
+            throw new RestAPIException( e);
         }
 
         //Notify tenant deactivation all listeners
@@ -1041,20 +941,19 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/service/definition")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response deployService(ServiceDefinitionBean serviceDefinitionBean)
+    @AuthorizationAction("/permission/admin/manage/add/service")
+    public Response deployService (ServiceDefinitionBean serviceDefinitionBean)
             throws RestAPIException {
 
-        log.info("Service definition request.. : " + serviceDefinitionBean.getServiceName());
-        // super tenant Deploying service (MT)
-        // here an alias is generated
-        ServiceUtils.deployService(serviceDefinitionBean.getCartridgeType(), UUID.randomUUID().toString(), serviceDefinitionBean.getAutoscalingPolicyName(),
-                serviceDefinitionBean.getDeploymentPolicyName(), getTenantDomain(), getUsername(), getTenantId(),
-                serviceDefinitionBean.getClusterDomain(), serviceDefinitionBean.getClusterSubDomain(),
-                serviceDefinitionBean.getTenantRange());
+    	log.info("Service definition request.. : " + serviceDefinitionBean.getServiceName());
+    	// super tenant Deploying service (MT) 
+    	// here an alias is generated
+       ServiceUtils.deployService(serviceDefinitionBean.getCartridgeType(), UUID.randomUUID().toString(), serviceDefinitionBean.getAutoscalingPolicyName(),
+               serviceDefinitionBean.getDeploymentPolicyName(), getTenantDomain(), getUsername(), getTenantId(),
+               serviceDefinitionBean.getClusterDomain(), serviceDefinitionBean.getClusterSubDomain(),
+               serviceDefinitionBean.getTenantRange());
 
-        URI url = uriInfo.getAbsolutePathBuilder().path(serviceDefinitionBean.getServiceName()).build();
+        URI url =  uriInfo.getAbsolutePathBuilder().path(serviceDefinitionBean.getServiceName()).build();
         return Response.created(url).build();
     }
 
@@ -1062,24 +961,24 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/service")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/service")
     public ServiceDefinitionBean[] getServices() throws RestAPIException {
         List<ServiceDefinitionBean> serviceDefinitionBeans = ServiceUtils.getdeployedServiceInformation();
         return serviceDefinitionBeans == null || serviceDefinitionBeans.isEmpty() ? new ServiceDefinitionBean[0] :
-                serviceDefinitionBeans.toArray(new ServiceDefinitionBean[serviceDefinitionBeans.size()]);
+            serviceDefinitionBeans.toArray(new ServiceDefinitionBean[serviceDefinitionBeans.size()]);
     }
 
     @GET
     @Path("/service/{serviceType}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getService(@PathParam("serviceType") String serviceType) throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/service")
+    public Response getService(@PathParam("serviceType") String serviceType)throws RestAPIException {
         ResponseBuilder rb;
         ServiceDefinitionBean serviceDefinitionBean = ServiceUtils.getDeployedServiceInformation(serviceType);
-        if (serviceDefinitionBean == null) {
+        if(serviceDefinitionBean == null){
             rb = Response.status(Response.Status.NOT_FOUND);
-        } else {
+        }else{
             rb = Response.ok(serviceDefinitionBean);
         }
         return rb.build();
@@ -1089,8 +988,8 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/service/active")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public List<Cartridge> getActiveService() throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/service")
+    public List<Cartridge> getActiveService()throws RestAPIException {
 
         return ServiceUtils.getActiveDeployedServiceInformation(getConfigContext());
     }
@@ -1099,13 +998,12 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/service/definition/{serviceType}")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    @SuperTenantService(true)
-    public Response unDeployService(@PathParam("serviceType") String serviceType) throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/add/service")
+    public Response unDeployService (@PathParam("serviceType") String serviceType) throws RestAPIException {
         try {
             ServiceUtils.undeployService(serviceType);
         } catch (ServiceDoesNotExistException e) {
-            return Response.status(Response.Status.NOT_FOUND).build();
+           return Response.status(Response.Status.NOT_FOUND).build();
         }
         return Response.noContent().build();
     }
@@ -1114,29 +1012,29 @@ public class StratosAdmin extends AbstractAdmin {
     @Path("/reponotification")
     @Produces("application/json")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/add/sync")
     public Response getRepoNotification(Payload payload) throws RestAPIException {
 
         ServiceUtils.getGitRepositoryNotification(payload);
         return Response.noContent().build();
     }
-
-    @POST
-    @Path("/cartridge/sync")
-    @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response synchronizeRepository(String alias) throws RestAPIException {
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Synchronizing Git repository for alias '%s'", alias));
-        }
-        CartridgeSubscription cartridgeSubscription = ServiceUtils.getCartridgeSubscription(alias, getConfigContext());
-        if (cartridgeSubscription != null && cartridgeSubscription.getRepository() != null && log.isDebugEnabled()) {
-            log.debug(String.format("Found subscription for '%s'. Git repository: %s", alias, cartridgeSubscription
-                    .getRepository().getUrl()));
-        }
-        ServiceUtils.synchronizeRepository(cartridgeSubscription);
+    
+	@POST
+	@Path("/cartridge/sync")
+	@Consumes("application/json")
+	@AuthorizationAction("/permission/admin/manage/add/sync")
+	public Response synchronizeRepository(String alias) throws RestAPIException {
+		if (log.isDebugEnabled()) {
+			log.debug(String.format("Synchronizing Git repository for alias '%s'", alias));
+		}
+		CartridgeSubscription cartridgeSubscription = ServiceUtils.getCartridgeSubscription(alias, getConfigContext());
+		if (cartridgeSubscription != null && cartridgeSubscription.getRepository() != null && log.isDebugEnabled()) {
+			log.debug(String.format("Found subscription for '%s'. Git repository: %s", alias, cartridgeSubscription
+					.getRepository().getUrl()));
+		}
+		ServiceUtils.synchronizeRepository(cartridgeSubscription);
         return Response.noContent().build();
-    }
+	}
 
     private List<TenantInfoBean> getAllTenants() throws RestAPIException {
         TenantManager tenantManager = ServiceHolder.getTenantManager();
@@ -1180,11 +1078,11 @@ public class StratosAdmin extends AbstractAdmin {
     @POST
     @Path("/cartridge/{cartridgeType}/subscription/{subscriptionAlias}/domains")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/add/domain")
     public Response addSubscriptionDomains(@PathParam("cartridgeType") String cartridgeType,
 
-                                           @PathParam("subscriptionAlias") String subscriptionAlias,
-                                           SubscriptionDomainRequest request) throws RestAPIException {
+                                                       @PathParam("subscriptionAlias") String subscriptionAlias,
+                                                       SubscriptionDomainRequest request) throws RestAPIException {
         ServiceUtils.addSubscriptionDomains(getConfigContext(), cartridgeType, subscriptionAlias, request);
         return Response.noContent().build();
     }
@@ -1192,14 +1090,14 @@ public class StratosAdmin extends AbstractAdmin {
     @GET
     @Path("/cartridge/{cartridgeType}/subscription/{subscriptionAlias}/domains")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
-    public Response getSubscriptionDomains(@PathParam("cartridgeType") String cartridgeType, @PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException {
+    @AuthorizationAction("/permission/admin/manage/view/domain")
+    public Response getSubscriptionDomains(@PathParam("cartridgeType") String cartridgeType,@PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException {
 
         SubscriptionDomainBean[] subscriptionDomainBean = ServiceUtils.getSubscriptionDomains(getConfigContext(), cartridgeType, subscriptionAlias).toArray(new SubscriptionDomainBean[0]);
 
-        if (subscriptionDomainBean.length == 0) {
+        if(subscriptionDomainBean.length == 0){
             return Response.status(Response.Status.NOT_FOUND).build();
-        } else {
+        }else{
             return Response.ok().entity(subscriptionDomainBean).build();
         }
     }
@@ -1207,13 +1105,13 @@ public class StratosAdmin extends AbstractAdmin {
     @GET
     @Path("/cartridge/{cartridgeType}/subscription/{subscriptionAlias}/domains/{domainName}")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/domain")
     public Response getSubscriptionDomain(@PathParam("cartridgeType") String cartridgeType, @PathParam("subscriptionAlias") String subscriptionAlias, @PathParam("domainName") String domainName) throws RestAPIException {
 
         SubscriptionDomainBean subscriptionDomainBean = ServiceUtils.getSubscriptionDomain(getConfigContext(), cartridgeType, subscriptionAlias, domainName);
-        if (subscriptionDomainBean.domainName == null) {
+        if(subscriptionDomainBean.domainName == null){
             return Response.status(Response.Status.NOT_FOUND).build();
-        } else {
+        }else{
             return Response.ok().entity(subscriptionDomainBean).build();
         }
     }
@@ -1221,10 +1119,10 @@ public class StratosAdmin extends AbstractAdmin {
     @DELETE
     @Path("/cartridge/{cartridgeType}/subscription/{subscriptionAlias}/domains/{domainName}")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/add/domain")
     public Response removeSubscriptionDomain(@PathParam("cartridgeType") String cartridgeType,
-                                             @PathParam("subscriptionAlias") String subscriptionAlias,
-                                             @PathParam("domainName") String domainName) throws RestAPIException {
+                                                         @PathParam("subscriptionAlias") String subscriptionAlias,
+                                                         @PathParam("domainName") String domainName) throws RestAPIException {
         try {
             ServiceUtils.removeSubscriptionDomain(getConfigContext(), cartridgeType, subscriptionAlias, domainName);
         } catch (DomainMappingExistsException e) {
@@ -1236,7 +1134,7 @@ public class StratosAdmin extends AbstractAdmin {
     @GET
     @Path("/cartridge/{cartridgeType}/subscription/{subscriptionAlias}/load-balancer-cluster")
     @Consumes("application/json")
-    @AuthorizationAction("/permission/protected/manage/monitor/tenants")
+    @AuthorizationAction("/permission/admin/manage/view/cluster")
     public Response getLoadBalancerCluster(@PathParam("cartridgeType") String cartridgeType,
                                            @PathParam("subscriptionAlias") String subscriptionAlias) throws RestAPIException {
         if (log.isDebugEnabled()) {
@@ -1251,5 +1149,127 @@ public class StratosAdmin extends AbstractAdmin {
             Response.fromResponse(getCluster(lbClusterId));
         }
         return Response.status(Response.Status.NOT_FOUND).build();
+    }
+@POST
+    @Path("/user")
+    @Consumes("application/json")
+    @Produces("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/users")
+    public Response addUser(UserInfoBean userInfoBean) throws RestAPIException {
+        ServiceUtils.addUser(userInfoBean);
+        URI url =  uriInfo.getAbsolutePathBuilder().path(userInfoBean.getUserName()).build();
+        return Response.created(url).build();
+    }
+
+    @DELETE
+    @Path("/user/{userName}")
+    @Consumes("application/json")
+    @Produces("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/users")
+    public Response deleteUser(@PathParam("userName") String userName) throws RestAPIException {
+        ServiceUtils.deleteUser(userName);
+        return Response.noContent().build();
+    }
+
+    @PUT
+    @Path("/user")
+    @Consumes("application/json")
+    @Produces("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/users")
+    public Response updateUser(UserInfoBean userInfoBean) throws RestAPIException {
+        ServiceUtils.updateUser(userInfoBean);
+        URI url =  uriInfo.getAbsolutePathBuilder().path(userInfoBean.getUserName()).build();
+        return Response.created(url).build();
+    }
+@POST
+    @Path("/kubernetes/deploy/group")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/kubernetes")
+    @SuperTenantService(true)
+    public Response deployKubernetesGroup(KubernetesGroup kubernetesGroup)
+            throws RestAPIException {
+
+        ServiceUtils.deployKubernetesGroup(kubernetesGroup);
+        URI url = uriInfo.getAbsolutePathBuilder().path(kubernetesGroup.getGroupId()).build();
+        return Response.created(url).build();
+    }
+
+    @POST
+    @Path("/kubernetes/deploy/host/{kubernetesGroupId}")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/kubernetes")
+    @SuperTenantService(true)
+    public Response deployKubernetesHost(@PathParam("kubernetesGroupId") String kubernetesGroupId, KubernetesHost kubernetesHost)
+            throws RestAPIException {
+
+        ServiceUtils.deployKubernetesHost(kubernetesGroupId, kubernetesHost);
+        URI url = uriInfo.getAbsolutePathBuilder().path(kubernetesHost.getHostId()).build();
+        return Response.created(url).build();
+    }
+
+    @PUT
+    @Path("/kubernetes/update/master")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/kubernetes")
+    @SuperTenantService(true)
+    public Response updateKubernetesMaster(KubernetesMaster kubernetesMaster)
+            throws RestAPIException {
+
+        ServiceUtils.updateKubernetesMaster(kubernetesMaster);
+        URI url = uriInfo.getAbsolutePathBuilder().path(kubernetesMaster.getHostId()).build();
+        return Response.created(url).build();
+    }
+
+    @GET
+    @Path("/kubernetes/group")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/view/kubernetes")
+    public Response getKubernetesGroups() throws RestAPIException {
+        return Response.ok().entity(ServiceUtils.getAvailableKubernetesGroups()).build();
+    }
+
+
+    @GET
+    @Path("/kubernetes/group/{kubernetesGroupId}")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/view/kubernetes")
+    public Response getKubernetesGroup(@PathParam("kubernetesGroupId") String kubernetesGroupId) throws RestAPIException {
+        return Response.ok().entity(ServiceUtils.getKubernetesGroup(kubernetesGroupId)).build();
+    }
+
+
+    @DELETE
+    @Path("/kubernetes/group/{kubernetesGroupId}")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/kubernetes")
+    @SuperTenantService(true)
+    public Response unDeployKubernetesGroup(@PathParam("kubernetesGroupId") String kubernetesGroupId) throws RestAPIException {
+        try {
+            ServiceUtils.undeployKubernetesGroup(kubernetesGroupId);
+        } catch (KubernetesGroupDoesNotExistException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("/kubernetes/group/{kubernetesHostId}")
+    @Produces("application/json")
+    @Consumes("application/json")
+    @AuthorizationAction("/permission/admin/manage/add/kubernetes")
+    @SuperTenantService(true)
+    public Response unDeployKubernetesHost(@PathParam("kubernetesHostId") String kubernetesHostId) throws RestAPIException {
+        try {
+            ServiceUtils.undeployKubernetesHost(kubernetesHostId);
+        } catch (KubernetesHostDoesNotExistException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.noContent().build();
     }
 }

--- a/components/org.apache.stratos.rest.endpoint/src/main/webapp/stratos-test/WEB-INF/schemas/schema.xsd
+++ b/components/org.apache.stratos.rest.endpoint/src/main/webapp/stratos-test/WEB-INF/schemas/schema.xsd
@@ -14,6 +14,20 @@
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="userInfoBean">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="userName" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="credential" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="role" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="firstName" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="lastName" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="email" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="profileName" type="xs:string" minOccurs="0" maxOccurs="1" nillable="false"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
     <xs:element name="partition">
         <xs:complexType>
             <xs:sequence>

--- a/components/org.apache.stratos.rest.endpoint/src/main/webapp/stratos/WEB-INF/schemas/schema.xsd
+++ b/components/org.apache.stratos.rest.endpoint/src/main/webapp/stratos/WEB-INF/schemas/schema.xsd
@@ -14,6 +14,20 @@
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="userInfoBean">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="userName" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="credential" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="role" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="firstName" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="lastName" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="email" type="xs:string" minOccurs="1" maxOccurs="1" nillable="false"/>
+                <xs:element name="profileName" type="xs:string" minOccurs="0" maxOccurs="1" nillable="false"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
     <xs:element name="partition">
         <xs:complexType>
             <xs:sequence>

--- a/components/org.apache.stratos.tenant.mgt.ui/src/main/resources/web/tenant-mgt/add_tenant.jsp
+++ b/components/org.apache.stratos.tenant.mgt.ui/src/main/resources/web/tenant-mgt/add_tenant.jsp
@@ -335,19 +335,19 @@
     var packageInfo;
     jQuery(document).ready(
                           function() {
-                              jQuery.ajax({
-                                  type: 'POST',
-                                  url: 'get_package_info_ajaxprocessor.jsp',
-                                  dataType: 'json',
-                                  data: 'plan=0',
-                                  async: false,
-                                  success: function(data) {
-                                      packageInfo = data;
-                                  },
-                                  error:function (xhr, ajaxOptions, thrownError) {
-                                      CARBON.showErrorDialog('Could not get package information.');
-                                  }
-                              });
+//                              jQuery.ajax({
+//                                  type: 'POST',
+//                                  url: 'get_package_info_ajaxprocessor.jsp',
+//                                  dataType: 'json',
+//                                  data: 'plan=0',
+//                                  async: false,
+//                                  success: function(data) {
+//                                      packageInfo = data;
+//                                  },
+//                                  error:function (xhr, ajaxOptions, thrownError) {
+//                                      CARBON.showErrorDialog('Could not get package information.');
+//                                  }
+//                              });
 
                               var charge;
                               var name;

--- a/products/stratos/modules/p2-profile-gen/pom.xml
+++ b/products/stratos/modules/p2-profile-gen/pom.xml
@@ -229,6 +229,8 @@
                                 <featureArtifactDef>org.wso2.carbon:org.wso2.carbon.sequences.server.feature:${carbon.version}</featureArtifactDef>
                                 <featureArtifactDef>org.wso2.carbon:org.wso2.carbon.mediators.server.feature:${carbon.version}</featureArtifactDef>
                                 <featureArtifactDef>org.wso2.carbon:org.wso2.carbon.relay.server.feature:${carbon.version}</featureArtifactDef>
+				<!--User Management-->
+				<featureArtifactDef>org.wso2.carbon:org.wso2.carbon.user.mgt.feature:${carbon.platform.patch.version.4.2.1}</featureArtifactDef>
                                 <!--CEP-->
                                 <featureArtifactDef>org.wso2.carbon:org.wso2.carbon.event.input.adaptor.feature:1.0.0</featureArtifactDef>
                                 <featureArtifactDef>org.wso2.carbon:org.wso2.carbon.event.output.adaptor.feature:1.0.0</featureArtifactDef>
@@ -438,6 +440,11 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.application.authentication.framework.server.feature.group</id>
                                     <version>4.2.1</version>
+                                </feature>
+				<!-- User Management features -->
+				<feature>
+                                     <id>org.wso2.carbon.user.mgt.feature.group</id>
+				     <version>${carbon.platform.patch.version.4.2.1}</version>
                                 </feature>
                             </features>
                         </configuration>
@@ -658,6 +665,12 @@
                                 <feature>
                                     <id>org.wso2.carbon.captcha.mgt.server.feature.group</id>
                                     <version>${carbon.version}</version>
+                                </feature>
+
+				<!-- User Management features -->
+				<feature>
+                                     <id>org.wso2.carbon.user.mgt.feature.group</id>
+				     <version>${carbon.platform.patch.version.4.2.1}</version>
                                 </feature>
 
                                 <!-- GApp SSO features -->


### PR DESCRIPTION
This PR adds basic carbon user management functionality to Stratos. At the server start-up and tenant creation time a new role 'Internal/user' will be created with relevant permissions which can be used to create Tenant Users. New REST API methods are added to add/update/delete users for users with relevant permissions. REST API @AuthorizationAction is now validated for super admin/tenant admin/user in order to give access to particular API methods.
