### PR TITLE
Adding changes related to sed -i for mac osx

### DIFF
--- a/tools/stratos-installer/demo.sh
+++ b/tools/stratos-installer/demo.sh
@@ -25,6 +25,15 @@
 # Die on any error:
 set -e
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 source "./conf/setup.conf"
 SLEEP=40
 export LOG=$log_path/stratos-ec2-user-data.log
@@ -101,19 +110,19 @@ if  [ -z "$DOMAIN" ]; then
 fi
 
 echo "Updating conf/setup.conf with user data"
-sed -i "s@export stratos_domain=\"*.*\"@export stratos_domain=\"$DOMAIN\"@g" conf/setup.conf
+${SED} -i "s@export stratos_domain=\"*.*\"@export stratos_domain=\"$DOMAIN\"@g" conf/setup.conf
 
-sed -i "s@export ec2_keypair_name=\"*.*\"@export ec2_keypair_name=\"$KEY_PAIR_NAME\"@g" conf/setup.conf
+${SED} -i "s@export ec2_keypair_name=\"*.*\"@export ec2_keypair_name=\"$KEY_PAIR_NAME\"@g" conf/setup.conf
 
-sed -i "s@export ec2_identity=\"*.*\"@export ec2_identity=\"$ACCESS_KEY\"@g" conf/setup.conf
+${SED} -i "s@export ec2_identity=\"*.*\"@export ec2_identity=\"$ACCESS_KEY\"@g" conf/setup.conf
 
-sed -i "s@export ec2_credential=\"*.*\"@export ec2_credential=\"$SECRET_KEY\"@g" conf/setup.conf
+${SED} -i "s@export ec2_credential=\"*.*\"@export ec2_credential=\"$SECRET_KEY\"@g" conf/setup.conf
 
-sed -i "s@export ec2_owner_id=\"*.*\"@export ec2_owner_id=\"$OWNER_ID\"@g" conf/setup.conf
+${SED} -i "s@export ec2_owner_id=\"*.*\"@export ec2_owner_id=\"$OWNER_ID\"@g" conf/setup.conf
 
-sed -i "s@export ec2_availability_zone=\"*.*\"@export ec2_availability_zone=\"$AVAILABILITY_ZONE\"@g" conf/setup.conf
+${SED} -i "s@export ec2_availability_zone=\"*.*\"@export ec2_availability_zone=\"$AVAILABILITY_ZONE\"@g" conf/setup.conf
 
-sed -i "s@export ec2_security_groups=\"*.*\"@export ec2_security_groups=\"$SECURITY_GROUP\"@g" conf/setup.conf
+${SED} -i "s@export ec2_security_groups=\"*.*\"@export ec2_security_groups=\"$SECURITY_GROUP\"@g" conf/setup.conf
 
 
 # Updating conf/setup.conf with relevent data
@@ -122,17 +131,17 @@ sed -i "s@export ec2_security_groups=\"*.*\"@export ec2_security_groups=\"$SECUR
 ip=`facter ipaddress`
 echo "Setting private ip addresses $ip" >> $LOG
 
-sed -i "s@export host_ip=\"*.*\"@export host_ip=\"$ip\"@g" conf/setup.conf
+${SED} -i "s@export host_ip=\"*.*\"@export host_ip=\"$ip\"@g" conf/setup.conf
 
-sed -i "s@export mb_ip=\"*.*\"@export mb_ip=\"$ip\"@g" conf/setup.conf
+${SED} -i "s@export mb_ip=\"*.*\"@export mb_ip=\"$ip\"@g" conf/setup.conf
 
-sed -i "s@export puppet_ip=\"*.*\"@export puppet_ip=\"$ip\"@g" conf/setup.conf
+${SED} -i "s@export puppet_ip=\"*.*\"@export puppet_ip=\"$ip\"@g" conf/setup.conf
 
-sed -i "s@export stratos_domain=\"*.*\"@export stratos_domain=\"$DOMAIN\"@g" conf/setup.conf
+${SED} -i "s@export stratos_domain=\"*.*\"@export stratos_domain=\"$DOMAIN\"@g" conf/setup.conf
 
-sed -i "s@\s*\$mb_ip\s*=\s*'.*'\s*@  \$mb_ip                = '$ip'@g" /etc/puppet/manifests/nodes.pp
+${SED} -i "s@\s*\$mb_ip\s*=\s*'.*'\s*@  \$mb_ip                = '$ip'@g" /etc/puppet/manifests/nodes.pp
 
-sed -i "s@\s*\$cep_ip\s*=\s*'.*'\s*@  \$cep_ip               = '$ip'@g" /etc/puppet/manifests/nodes.pp
+${SED} -i "s@\s*\$cep_ip\s*=\s*'.*'\s*@  \$cep_ip               = '$ip'@g" /etc/puppet/manifests/nodes.pp
 
 hostname $puppet_hostname
 service puppetmaster restart

--- a/tools/stratos-installer/ec2.sh
+++ b/tools/stratos-installer/ec2.sh
@@ -26,6 +26,15 @@
 # Die on any error:
 set -e
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 SLEEP=60
 export LOG=$log_path/stratos-ec2.log
 
@@ -41,18 +50,18 @@ pushd $stratos_extract_path
 
 echo "Set EC2 provider specific info in repository/conf/cloud-controller.xml" >> $LOG
 
-sed -i "s@EC2_PROVIDER_START@@g"  repository/conf/cloud-controller.xml
-sed -i "s@EC2_IDENTITY@$ec2_identity@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_CREDENTIAL@$ec2_credential@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_OWNER_ID@$ec2_owner_id@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_AVAILABILITY_ZONE@$ec2_availability_zone@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_SECURITY_GROUPS@$ec2_security_groups@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_KEYPAIR@$ec2_keypair_name@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_PROVIDER_END@@g" repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
-sed -i "s@VCLOUD_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
-sed -i "s@VCLOUD_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_PROVIDER_START@@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_IDENTITY@$ec2_identity@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_CREDENTIAL@$ec2_credential@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_OWNER_ID@$ec2_owner_id@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_AVAILABILITY_ZONE@$ec2_availability_zone@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_SECURITY_GROUPS@$ec2_security_groups@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_KEYPAIR@$ec2_keypair_name@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_PROVIDER_END@@g" repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
 
 popd
 

--- a/tools/stratos-installer/openstack.sh
+++ b/tools/stratos-installer/openstack.sh
@@ -26,6 +26,15 @@
 # Die on any error:
 set -e
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 SLEEP=60
 export LOG=$log_path/stratos-openstack.log
 
@@ -41,16 +50,16 @@ pushd $stratos_extract_path
 
 echo "Set OpenStack provider specific info in repository/conf/cloud-controller.xml" >> $LOG
 
-sed -i "s@OPENSTACK_PROVIDER_START@@g" repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_IDENTITY@$openstack_identity@g"  repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_CREDENTIAL@$openstack_credential@g"  repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_ENDPOINT@$openstack_jclouds_endpoint@g"  repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_PROVIDER_END@@g"  repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_SECURITY_GROUPS@$openstack_security_groups@g" repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_KEYPAIR@$openstack_keypair_name@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_PROVIDER_START@!--@g"  repository/conf/cloud-controller.xml
-sed -i "s@EC2_PROVIDER_END@--@g"  repository/conf/cloud-controller.xml
-sed -i "s@VCLOUD_PROVIDER_START@!--@g"  repository/conf/cloud-controller.xml
-sed -i "s@VCLOUD_PROVIDER_END@--@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_PROVIDER_START@@g" repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_IDENTITY@$openstack_identity@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_CREDENTIAL@$openstack_credential@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_ENDPOINT@$openstack_jclouds_endpoint@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_PROVIDER_END@@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_SECURITY_GROUPS@$openstack_security_groups@g" repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_KEYPAIR@$openstack_keypair_name@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_PROVIDER_START@!--@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_PROVIDER_END@--@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_PROVIDER_START@!--@g"  repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_PROVIDER_END@--@g"  repository/conf/cloud-controller.xml
 
 popd

--- a/tools/stratos-installer/scripts/add_entry_zone_file.sh
+++ b/tools/stratos-installer/scripts/add_entry_zone_file.sh
@@ -23,6 +23,15 @@ zone_file=$3
 subdomain=$1
 ip=$2
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 # check the file
 if [ -f {$zone_file} ]; then
 	echo "Error: zone does not exist"
@@ -62,7 +71,7 @@ if [ $serialdate = $date ]
 fi
 
 echo "Adding subdomain $1 and ip $2 to $3"
-sed -i "s/.*Serial.*/ \t\t\t\t$newserial ; Serial./" $zone_file
+${SED} -i "s/.*Serial.*/ \t\t\t\t$newserial ; Serial./" $zone_file
 
 
 

--- a/tools/stratos-installer/scripts/remove_entry_zone_file.sh
+++ b/tools/stratos-installer/scripts/remove_entry_zone_file.sh
@@ -22,6 +22,15 @@
 zone_file=$2
 subdomain=$1
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 # check the file
 if [ -f {$zone_file} ]; then
 	echo "Error: zone does not exist"
@@ -67,7 +76,7 @@ if [ $serialdate = $date ]
 fi
 
 echo "Adding subdomain $1 and ip $2 to $3"
-sed -i "s/.*Serial.*/ \t\t\t\t$newserial ; Serial./" $zone_file
+${SED} -i "s/.*Serial.*/ \t\t\t\t$newserial ; Serial./" $zone_file
 
 
 

--- a/tools/stratos-installer/setup.sh
+++ b/tools/stratos-installer/setup.sh
@@ -26,6 +26,15 @@
 # Die on any error:
 set -e
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 source "./conf/setup.conf"
 export LOG=$log_path/stratos-setup.log
 
@@ -138,10 +147,10 @@ function general_setup() {
 
     pushd $stratos_extract_path
     echo "In repository/conf/carbon.xml"
-    sed -i "s@<Offset>0</Offset>@<Offset>${offset}</Offset>@g" repository/conf/carbon.xml
+    ${SED} -i "s@<Offset>0</Offset>@<Offset>${offset}</Offset>@g" repository/conf/carbon.xml
 
     echo "In repository/conf/jndi.properties"
-    sed -i "s@MB_HOSTNAME:MB_LISTEN_PORT@$mb_ip:$mb_port@g" repository/conf/jndi.properties
+    ${SED} -i "s@MB_HOSTNAME:MB_LISTEN_PORT@$mb_ip:$mb_port@g" repository/conf/jndi.properties
     popd
 
 }
@@ -290,10 +299,10 @@ function as_setup() {
     pushd $stratos_extract_path
 
     echo "In repository/conf/autoscaler.xml"
-    sed -i "s@CC_HOSTNAME@$cc_hostname@g" repository/conf/autoscaler.xml
-    sed -i "s@CC_LISTEN_PORT@$as_cc_https_port@g" repository/conf/autoscaler.xml
-    sed -i "s@SM_HOSTNAME@$sm_hostname@g" repository/conf/autoscaler.xml
-    sed -i "s@SM_LISTEN_PORT@$as_sm_https_port@g" repository/conf/autoscaler.xml
+    ${SED} -i "s@CC_HOSTNAME@$cc_hostname@g" repository/conf/autoscaler.xml
+    ${SED} -i "s@CC_LISTEN_PORT@$as_cc_https_port@g" repository/conf/autoscaler.xml
+    ${SED} -i "s@SM_HOSTNAME@$sm_hostname@g" repository/conf/autoscaler.xml
+    ${SED} -i "s@SM_LISTEN_PORT@$as_sm_https_port@g" repository/conf/autoscaler.xml
 
     popd
     echo "End configuring the Autoscaler"
@@ -381,18 +390,18 @@ function sm_setup() {
     pushd $stratos_extract_path
 
     echo "In repository/conf/cartridge-config.properties"
-    sed -i "s@CC_HOSTNAME:CC_HTTPS_PORT@$cc_hostname:$sm_cc_https_port@g" repository/conf/cartridge-config.properties
-    sed -i "s@AS_HOSTNAME:AS_HTTPS_PORT@$as_hostname:$sm_as_https_port@g" repository/conf/cartridge-config.properties
-    sed -i "s@PUPPET_IP@$puppet_ip@g" repository/conf/cartridge-config.properties
-    sed -i "s@PUPPET_HOSTNAME@$puppet_hostname@g" repository/conf/cartridge-config.properties
-    sed -i "s@PUPPET_ENV@$puppet_environment@g" repository/conf/cartridge-config.properties
+    ${SED} -i "s@CC_HOSTNAME:CC_HTTPS_PORT@$cc_hostname:$sm_cc_https_port@g" repository/conf/cartridge-config.properties
+    ${SED} -i "s@AS_HOSTNAME:AS_HTTPS_PORT@$as_hostname:$sm_as_https_port@g" repository/conf/cartridge-config.properties
+    ${SED} -i "s@PUPPET_IP@$puppet_ip@g" repository/conf/cartridge-config.properties
+    ${SED} -i "s@PUPPET_HOSTNAME@$puppet_hostname@g" repository/conf/cartridge-config.properties
+    ${SED} -i "s@PUPPET_ENV@$puppet_environment@g" repository/conf/cartridge-config.properties
 
     echo "In repository/conf/datasources/master-datasources.xml"
-    sed -i "s@USERSTORE_DB_HOSTNAME@$userstore_db_hostname@g" repository/conf/datasources/master-datasources.xml
-    sed -i "s@USERSTORE_DB_PORT@$userstore_db_port@g" repository/conf/datasources/master-datasources.xml
-    sed -i "s@USERSTORE_DB_SCHEMA@$userstore_db_schema@g" repository/conf/datasources/master-datasources.xml
-    sed -i "s@USERSTORE_DB_USER@$userstore_db_user@g" repository/conf/datasources/master-datasources.xml
-    sed -i "s@USERSTORE_DB_PASS@$userstore_db_pass@g" repository/conf/datasources/master-datasources.xml
+    ${SED} -i "s@USERSTORE_DB_HOSTNAME@$userstore_db_hostname@g" repository/conf/datasources/master-datasources.xml
+    ${SED} -i "s@USERSTORE_DB_PORT@$userstore_db_port@g" repository/conf/datasources/master-datasources.xml
+    ${SED} -i "s@USERSTORE_DB_SCHEMA@$userstore_db_schema@g" repository/conf/datasources/master-datasources.xml
+    ${SED} -i "s@USERSTORE_DB_USER@$userstore_db_user@g" repository/conf/datasources/master-datasources.xml
+    ${SED} -i "s@USERSTORE_DB_PASS@$userstore_db_pass@g" repository/conf/datasources/master-datasources.xml
 
     popd
 
@@ -402,7 +411,7 @@ function sm_setup() {
     echo "Creating userstore database"
 
     pushd $resource_path
-    sed -i "s@USERSTORE_DB_SCHEMA@$userstore_db_schema@g" mysql.sql
+    ${SED} -i "s@USERSTORE_DB_SCHEMA@$userstore_db_schema@g" mysql.sql
 
     popd
 
@@ -420,8 +429,8 @@ function cep_setup() {
 
     echo "In outputeventadaptors"
 
-    sed -i "s@CEP_HOME@$stratos_extract_path@g" repository/deployment/server/outputeventadaptors/JMSOutputAdaptor.xml
-    sed -i "s@MB_HOSTNAME:MB_LISTEN_PORT@$mb_ip:$mb_port@g" repository/deployment/server/outputeventadaptors/JMSOutputAdaptor.xml
+    ${SED} -i "s@CEP_HOME@$stratos_extract_path@g" repository/deployment/server/outputeventadaptors/JMSOutputAdaptor.xml
+    ${SED} -i "s@MB_HOSTNAME:MB_LISTEN_PORT@$mb_ip:$mb_port@g" repository/deployment/server/outputeventadaptors/JMSOutputAdaptor.xml
 
     echo "End configuring the Complex Event Processor"
     popd
@@ -537,7 +546,7 @@ if [[ ($profile = "default" && $config_mb = "true") ]]; then
     echo "Extracting ActiveMQ"
     tar -xzf $activemq_pack -C $stratos_path
     # disable amqp connector to prevent conflicts with openstack
-    sed -r -i -e 's@^(\s*)(<transportConnector name="amqp".*\s*)$@\1<!--\2-->@g' $activemq_path/conf/activemq.xml
+    ${SED} -r -i -e 's@^(\s*)(<transportConnector name="amqp".*\s*)$@\1<!--\2-->@g' $activemq_path/conf/activemq.xml
 fi
 
 general_setup
@@ -578,7 +587,7 @@ mv -f ./hosts.tmp /etc/hosts
 # Starting the servers
 # ------------------------------------------------
 echo 'Changing owner of '$stratos_path' to '$host_user:$host_user
-chown $host_user:$host_user $stratos_path -R
+chown -R $host_user:$host_user $stratos_path
 
 echo "Apache Stratos configuration completed successfully"
 
@@ -593,7 +602,7 @@ echo "Starting the servers" >> $LOG
 
 echo "Starting up servers. This may take time. Look at $LOG file for server startup details"
 
-chown -R $host_user.$host_user $log_path
+chown -R $host_user:$host_user $log_path
 chmod -R 777 $log_path
 
 export setup_dir=$PWD

--- a/tools/stratos-installer/vcloud.sh
+++ b/tools/stratos-installer/vcloud.sh
@@ -26,6 +26,15 @@
 # Die on any error:
 set -e
 
+# General commands
+if [ "$(uname)" == "Darwin" ]; then
+    # Do something under Mac OS X platform  
+	SED=`which gsed` && : || (echo "Command 'gsed' is not installed."; exit 10;)
+else
+    # Do something else under some other platform
+    SED=`which sed` && : || (echo "Command 'sed' is not installed."; exit 10;)
+fi
+
 SLEEP=60
 export LOG=$log_path/stratos-vcloud.log
 
@@ -41,14 +50,14 @@ pushd $stratos_extract_path
 
 echo "Set vCloud provider specific info in repository/conf/cloud-controller.xml" >> $LOG
 
-sed -i "s@VCLOUD_PROVIDER_START@@g" repository/conf/cloud-controller.xml
-sed -i "s/VCLOUD_IDENTITY/$vcloud_identity/g" repository/conf/cloud-controller.xml
-sed -i "s/VCLOUD_CREDENTIAL/$vcloud_credential/g" repository/conf/cloud-controller.xml
-sed -i "s@VCLOUD_ENDPOINT@$vcloud_jclouds_endpoint@g" repository/conf/cloud-controller.xml
-sed -i "s@VCLOUD_PROVIDER_END@@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
-sed -i "s@EC2_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
-sed -i "s@OPENSTACK_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_PROVIDER_START@@g" repository/conf/cloud-controller.xml
+${SED} -i "s/VCLOUD_IDENTITY/$vcloud_identity/g" repository/conf/cloud-controller.xml
+${SED} -i "s/VCLOUD_CREDENTIAL/$vcloud_credential/g" repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_ENDPOINT@$vcloud_jclouds_endpoint@g" repository/conf/cloud-controller.xml
+${SED} -i "s@VCLOUD_PROVIDER_END@@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@EC2_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_PROVIDER_START@!--@g" repository/conf/cloud-controller.xml
+${SED} -i "s@OPENSTACK_PROVIDER_END@--@g" repository/conf/cloud-controller.xml
 
 popd


### PR DESCRIPTION
This change is mainly due to incompatibility issues occurred in stratos when user run it on a mac os x.
A work around solution is to use gsed instead of sed.
How to install gsed in mac osx:
   i. Installed homebrew(http://brew.sh/)
    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
    ii. Installed gnu-sed
    $ brew install gnu-sed

changes are made in:
stratos / tools / stratos-installer /
  demo.sh, ec2.sh,openstack.sh, setup.sh and vcloud.sh
stratos / tools / stratos-installer / scripts /
  add_entry_zone_file.sh and remove_entry_zone_file.sh 

Other than that this change also include syntax errors which can be found in setup.sh line 605:
-chown -R $host_user.$host_user $log_path
+chown -R $host_user:$host_user $log_path
This code change is done by @Prasanna Dangalla

JIRA - https://issues.apache.org/jira/browse/STRATOS-816
