### PR TITLE
removed jps which displayed java processes in clean.sh

### DIFF
--- a/tools/stratos-installer/clean.sh
+++ b/tools/stratos-installer/clean.sh
@@ -81,8 +81,6 @@ if [[ ( -n $mysql_user && -n $mysql_pass ) ]]; then
 	fi
 fi
 echo 'Stopping Carbon java processes'
-jps -mlV
-
 #killing carbon processes
 for pid in $(ps aux | grep "[o]rg.wso2.carbon.bootstrap.Bootstrap" | awk '{print $2}')
 do


### PR DESCRIPTION
Removed the jps command which might not be detected when running the script. No functional change since jps was used to just display the Java related processes. 
