### PR TITLE
Correction startupOrders

### DIFF
--- a/samples/complex-app/ec2/artifacts/application_definition.json
+++ b/samples/complex-app/ec2/artifacts/application_definition.json
@@ -89,7 +89,7 @@
         ],
         "dependencies": {
             "startupOrders": [
-                "group.mygroup8,cartridge.mytomcat,group.mygroup6"
+                "group.group8,cartridge.tomcat,group.group6"
             ],
             "terminationBehaviour": "terminate-all"
         }


### PR DESCRIPTION
Changing "group.mygroup8,cartridge.mytomcat,group.mygroup6" to "group.group8,cartridge.tomcat,group.group6"
startupOrders should not be alias.