### PR TITLE
Fixed logging.ini puppet template for cartridge agent to include /mnt/{agent}/agent.log file

### DIFF
--- a/tools/puppet3/modules/python_agent/templates/logging.ini.erb
+++ b/tools/puppet3/modules/python_agent/templates/logging.ini.erb
@@ -6,7 +6,7 @@ format=%(asctime)s:%(levelname)s:%(message)s
 class=logging.Formatter
 
 [handlers]
-keys=console, error_file
+keys=console, error_file, log_file
 
 [handler_console]
 class=logging.StreamHandler


### PR DESCRIPTION
The puppet module for cartridge agent included faulty logging.ini[.erb] file which excluded the agent.log file being created. 