### PR TITLE
Validate removal of cartridges cartridgegroups

### DIFF
--- a/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/client/StratosManagerServiceClient.java
+++ b/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/client/StratosManagerServiceClient.java
@@ -33,6 +33,7 @@ import org.apache.stratos.manager.service.stub.domain.application.signup.Applica
 import org.apache.stratos.manager.service.stub.domain.application.signup.DomainMapping;
 
 import java.rmi.RemoteException;
+import java.util.List;
 
 /**
  * Stratos manager service client.
@@ -154,5 +155,115 @@ public class StratosManagerServiceClient {
 
     public DomainMapping[] getDomainMappings(String applicationId, int tenantId) throws RemoteException, StratosManagerServiceDomainMappingExceptionException {
         return stub.getDomainMappings(applicationId, tenantId);
+    }
+    
+    /**
+     * Adds the used cartridges in cartridge groups to cache.
+     *
+     * @param cartridgeGroupName the cartridge group name
+     * @param cartridgeNames the cartridge names
+     * @throws RemoteException the remote exception
+     */
+    public void addUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames) throws RemoteException {
+    	stub.addUsedCartridgesInCartridgeGroups(cartridgeGroupName, cartridgeNames);
+    }
+    
+    /**
+     * Removes the used cartridges in cartridge groups from cache.
+     *
+     * @param cartridgeGroupName the cartridge group name
+     * @param cartridgeNames the cartridge names
+     * @throws RemoteException the remote exception
+     */
+    public void removeUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames) throws RemoteException {
+    	stub.removeUsedCartridgesInCartridgeGroups(cartridgeGroupName, cartridgeNames);
+    }
+    
+    /**
+     * Adds the used cartridges in applications to cache.
+     *
+     * @param applicationName the application name
+     * @param cartridgeNames the cartridge names
+     * @throws RemoteException the remote exception
+     */
+    public void addUsedCartridgesInApplications(String applicationName, String[] cartridgeNames) throws RemoteException {
+    	stub.addUsedCartridgesInApplications(applicationName, cartridgeNames);
+    }
+    
+    /**
+     * Removes the used cartridges in applications from cache.
+     *
+     * @param applicationName the application name
+     * @param cartridgeNames the cartridge names
+     * @throws RemoteException the remote exception
+     */
+    public void removeUsedCartridgesInApplications(String applicationName, String[] cartridgeNames) throws RemoteException {
+    	stub.removeUsedCartridgesInApplications(applicationName, cartridgeNames);
+    }
+    
+    /**
+     * Validates whether a cartridge can be removed.
+     *
+     * @param cartridgeName the cartridge name
+     * @return true, if successful
+     * @throws RemoteException the remote exception
+     */
+    public boolean canCartridgeBeRemoved(String cartridgeName) throws RemoteException {
+    	return stub.canCartridgeBeRemoved(cartridgeName);
+    }
+    
+    /**
+     * Adds the used cartridge groups in cartridge sub groups to cache.
+     *
+     * @param cartridgeSubGroupName the cartridge sub group name
+     * @param cartridgeGroupNames the cartridge group names
+     * @throws RemoteException the remote exception
+     */
+    public void addUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames) throws RemoteException {
+    	stub.addUsedCartridgeGroupsInCartridgeSubGroups(cartridgeSubGroupName, cartridgeGroupNames);
+    }
+        
+    /**
+     * Removes the used cartridge groups in cartridge sub groups from cache.
+     *
+     * @param cartridgeSubGroupName the cartridge sub group name
+     * @param cartridgeGroupNames the cartridge group names
+     * @throws RemoteException the remote exception
+     */
+    public void removeUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames) throws RemoteException {
+    	stub.removeUsedCartridgeGroupsInCartridgeSubGroups(cartridgeSubGroupName, cartridgeGroupNames);
+    }
+    
+    /**
+     * Adds the used cartridge groups in applications to cache.
+     *
+     * @param applicationName the application name
+     * @param cartridgeGroupNames the cartridge group names
+     * @throws RemoteException the remote exception
+     */
+    public void addUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames) throws RemoteException {
+    	stub.addUsedCartridgeGroupsInApplications(applicationName, cartridgeGroupNames);
+    }
+    
+    /**
+     * Removes the used cartridge groups in applications from cache.
+     *
+     * @param applicationName the application name
+     * @param cartridgeGroupNames the cartridge group names
+     * @throws RemoteException the remote exception
+     */
+    public void removeUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames) throws RemoteException {
+    	stub.removeUsedCartridgeGroupsInApplications(applicationName, cartridgeGroupNames);
+    }
+    
+    /**
+     * Validates whether a cartridge group can be removed.
+     *
+     * @param cartridgeGroupName the cartridge group name
+     * @return true, if successful
+     * @throws RemoteException the remote exception
+     */
+    public boolean canCartirdgeGroupBeRemoved(String cartridgeGroupName) throws RemoteException {
+    	return stub.canCartirdgeGroupBeRemoved(cartridgeGroupName);
     }
 }

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/context/StratosManagerContext.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/context/StratosManagerContext.java
@@ -19,16 +19,70 @@
 
 package org.apache.stratos.manager.context;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+
 import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.stratos.manager.registry.RegistryManager;
+import org.apache.stratos.common.clustering.DistributedObjectProvider;
 import org.apache.stratos.manager.internal.ServiceReferenceHolder;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
 
 /**
  * Stratos manager context.
  */
-public class StratosManagerContext {
+public class StratosManagerContext implements Serializable {
 
-    private static volatile StratosManagerContext instance;
+	
 
+	private static volatile StratosManagerContext instance;
+    
+    private static final String SM_CARTRIDGE_TYPE_TO_CARTIDGE_GROUPS_MAP = "SM_CARTRIDGE_TYPE_TO_CARTIDGE_GROUPS_MAP";
+    private static final String SM_CARTRIDGE_TYPE_TO_APPLICATIONS_MAP = "SM_CARTRIDGE_TYPE_TO_APPLICATIONS_MAP";
+    private static final String SM_CARTRIDGE_GROUP_TO_CARTIDGE_GROUPS_MAP = "SM_CARTRIDGE_GROUP_TO_CARTIDGE_GROUPS_MAP";
+    private static final String SM_CARTRIDGE_GROUP_TO_APPLICATIONS_MAP = "SM_CARTRIDGE_GROUP_TO_APPLICATIONS_MAP";
+    
+    private static final String SM_CARTRIDGES_CARTRIDGEGROUPS_WRITE_LOCK = "SM_CARTRIDGES_CARTRIDGEGROUPS_WRITE_LOCK";
+    private static final String SM_CARTRIDGES_APPLICATIONS_WRITE_LOCK = "SM_CARTRIDGES_APPLICATIONS_WRITE_LOCK";
+    private static final String SM_CARTRIDGEGROUPS_CARTRIDGESUBGROUPS_WRITE_LOCK = "SM_CARTRIDGEGROUPS_CARTRIDGESUBGROUPS_WRITE_LOCK";
+    private static final String SM_CARTRIDGEGROUPS_APPLICATIONS_WRITE_LOCK = "SM_CARTRIDGEGROUPS_APPLICATIONS_WRITE_LOCK";
+    
+    public static final String DATA_RESOURCE = "/stratos.manager/data";
+   
+    private final transient DistributedObjectProvider distributedObjectProvider;
+    private static final Log log = LogFactory.getLog(StratosManagerContext.class);
+    
+    /**
+     * Key - cartridge type
+     * Value - list of cartridgeGroupNames
+     */
+    private Map<String, Set<String>> cartridgeTypeToCartridgeGroupsMap;
+    
+    /**
+     * Key - cartridge type
+     * Value - list of ApplicationNames
+     */
+    private Map<String, Set<String>> cartridgeTypeToApplicationsMap;
+    
+    /**
+     * Key - cartridge group name
+     * Value - list of cartridgeGroupNames
+     */
+    private Map<String, Set<String>> cartridgeGroupToCartridgeSubGroupsMap;
+    
+    /**
+     * Key - cartridge group name
+     * Value - list of ApplicationNames
+     */
+    private Map<String, Set<String>> cartridgeGroupToApplicationsMap;
+    
     private boolean clustered;
     private boolean coordinator;
 
@@ -49,6 +103,18 @@ public class StratosManagerContext {
         if ((axisConfiguration != null) && (axisConfiguration.getClusteringAgent() != null)) {
             clustered = true;
         }
+        
+        // Initialize distributed object provider
+        distributedObjectProvider = ServiceReferenceHolder.getInstance().getDistributedObjectProvider();
+        
+        // Get maps from distributed object provider
+        cartridgeTypeToCartridgeGroupsMap = distributedObjectProvider.getMap(SM_CARTRIDGE_TYPE_TO_CARTIDGE_GROUPS_MAP);
+        cartridgeTypeToApplicationsMap = distributedObjectProvider.getMap(SM_CARTRIDGE_TYPE_TO_APPLICATIONS_MAP);
+        cartridgeGroupToCartridgeSubGroupsMap = distributedObjectProvider.getMap(SM_CARTRIDGE_GROUP_TO_CARTIDGE_GROUPS_MAP);
+        cartridgeGroupToApplicationsMap = distributedObjectProvider.getMap(SM_CARTRIDGE_GROUP_TO_APPLICATIONS_MAP);
+        
+        // Update context from the registry
+        updateContextFromRegistry();
     }
 
     public void setCoordinator(boolean coordinator) {
@@ -61,5 +127,263 @@ public class StratosManagerContext {
 
     public boolean isClustered() {
         return clustered;
+    }
+    
+    private Lock acquireWriteLock(String object) {
+        return distributedObjectProvider.acquireLock(object);
+    }
+
+    public void releaseWriteLock(Lock lock) {
+        distributedObjectProvider.releaseLock(lock);
+    }
+    
+    public Lock acquireCartridgesCartridgeGroupsWriteLock() {
+        return acquireWriteLock(SM_CARTRIDGES_CARTRIDGEGROUPS_WRITE_LOCK);
+    }
+    
+    public Lock acquireCartridgesApplicationsWriteLock() {
+        return acquireWriteLock(SM_CARTRIDGES_APPLICATIONS_WRITE_LOCK);
+    }
+
+    public Lock acquireCartridgeGroupsCartridgeSubGroupsWriteLock() {
+        return acquireWriteLock(SM_CARTRIDGEGROUPS_CARTRIDGESUBGROUPS_WRITE_LOCK);
+    }
+    
+    public Lock acquireCartridgeGroupsApplicationsWriteLock() {
+        return acquireWriteLock(SM_CARTRIDGEGROUPS_APPLICATIONS_WRITE_LOCK);
+    }
+    
+    public void addUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames) {
+    	if(cartridgeNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeName : cartridgeNames) {
+    		Set<String> cartridgeGroupNames = null;
+    		if(cartridgeTypeToCartridgeGroupsMap.containsKey(cartridgeName)) {
+    			cartridgeGroupNames = cartridgeTypeToCartridgeGroupsMap.get(cartridgeName);
+    		} else {
+    			cartridgeGroupNames = new HashSet<String>();
+    			cartridgeTypeToCartridgeGroupsMap.put(cartridgeName, cartridgeGroupNames);
+    		}
+    		cartridgeGroupNames.add(cartridgeGroupName);
+    	}
+    }
+    
+    public void removeUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames) {
+    	if(cartridgeNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeName : cartridgeNames) {
+    		Set<String> cartridgeGroupNames = null;
+    		if(cartridgeTypeToCartridgeGroupsMap.containsKey(cartridgeName)) {
+    			cartridgeGroupNames = cartridgeTypeToCartridgeGroupsMap.get(cartridgeName);
+    			// Remove current cartridge group name
+    			cartridgeGroupNames.remove(cartridgeGroupName);
+    			// Remove entry if there are no more cartridge group names for that cartridge type
+    			if (cartridgeGroupNames.isEmpty()) {
+    				cartridgeGroupNames = null;
+    				cartridgeTypeToCartridgeGroupsMap.remove(cartridgeName);
+    			}
+    		} 
+    	}
+    }
+    
+    public boolean isCartridgeIncludedInCartridgeGroups(String cartridgeName) {
+    	if(cartridgeTypeToApplicationsMap.containsKey(cartridgeName)) {
+    		if(!cartridgeTypeToApplicationsMap.get(cartridgeName).isEmpty()) {
+        		return true;
+    		}
+    		return false;
+    	}
+    	return false;
+    }
+    
+    public void addUsedCartridgesInApplications(String applicationName, String[] cartridgeNames) {
+    	if(cartridgeNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeName : cartridgeNames) {
+    		Set<String> applicationNames = null;
+    		if(cartridgeTypeToApplicationsMap.containsKey(cartridgeName)) {
+    			applicationNames = cartridgeTypeToApplicationsMap.get(cartridgeName);
+    		} else {
+    			applicationNames = new HashSet<String>();
+    			cartridgeTypeToApplicationsMap.put(cartridgeName, applicationNames);
+    		}
+    		applicationNames.add(applicationName);
+    	}
+    }
+    
+    public void removeUsedCartridgesInApplications(String applicationName, String[] cartridgeNames) {
+    	if(cartridgeNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeName : cartridgeNames) {
+    		Set<String> applicationNames = null;
+    		if(cartridgeTypeToApplicationsMap.containsKey(cartridgeName)) {
+    			applicationNames = cartridgeTypeToApplicationsMap.get(cartridgeName);
+    			// Remove current application name
+    			applicationNames.remove(applicationName);
+    			// Remove entry if there are no more cartridge group names for that cartridge type
+    			if (applicationNames.isEmpty()) {
+    				applicationNames = null;
+    				cartridgeTypeToApplicationsMap.remove(cartridgeName);
+    			}
+    		} 
+    	}
+    }
+    
+    public boolean isCartridgeIncludedInApplications(String cartridgeName) {
+    	if(cartridgeTypeToApplicationsMap.containsKey(cartridgeName)) {
+    		if(!cartridgeTypeToApplicationsMap.get(cartridgeName).isEmpty()) {
+        		return true;
+    		}
+    		return false;
+    	}
+    	return false;
+    }
+    
+    public void addUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames) {
+    	if(cartridgeGroupNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeGroupName : cartridgeGroupNames) {
+    		Set<String> cartridgeSubGroupNames = null;
+    		if(cartridgeGroupToCartridgeSubGroupsMap.containsKey(cartridgeGroupName)) {
+    			cartridgeSubGroupNames = cartridgeTypeToCartridgeGroupsMap.get(cartridgeGroupName);
+    		} else {
+    			cartridgeSubGroupNames = new HashSet<String>();
+    			cartridgeGroupToCartridgeSubGroupsMap.put(cartridgeSubGroupName, cartridgeSubGroupNames);
+    		}
+    		cartridgeSubGroupNames.add(cartridgeGroupName);
+    	}
+    }
+    
+    public void removeUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames) {
+    	if(cartridgeGroupNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeGroupName : cartridgeGroupNames) {
+    		Set<String> cartridgeSubGroupNames = null;
+    		if(cartridgeGroupToCartridgeSubGroupsMap.containsKey(cartridgeGroupName)) {
+    			cartridgeSubGroupNames = cartridgeGroupToCartridgeSubGroupsMap.get(cartridgeGroupName);
+    			// Remove current cartridge group name
+    			cartridgeSubGroupNames.remove(cartridgeGroupName);
+    			// Remove entry if there are no more cartridge group names for that cartridge type
+    			if (cartridgeSubGroupNames.isEmpty()) {
+    				cartridgeSubGroupNames = null;
+    				cartridgeGroupToCartridgeSubGroupsMap.remove(cartridgeGroupName);
+    			}
+    		} 
+    	}
+    }
+    
+    public boolean isCartridgeGroupIncludedInCartridgeSubGroups(String cartridgeGroupName) {
+    	if(cartridgeGroupToCartridgeSubGroupsMap.containsKey(cartridgeGroupName)) {
+    		if(!cartridgeGroupToCartridgeSubGroupsMap.get(cartridgeGroupName).isEmpty()) {
+        		return true;
+    		}
+    		return false;
+    	}
+    	return false;
+    }
+    
+    public void addUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames) {
+    	if(cartridgeGroupNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeGroupName : cartridgeGroupNames) {
+    		Set<String> applicationNames = null;
+    		if(cartridgeGroupToApplicationsMap.containsKey(cartridgeGroupName)) {
+    			applicationNames = cartridgeGroupToApplicationsMap.get(cartridgeGroupName);
+    		} else {
+    			applicationNames = new HashSet<String>();
+    			cartridgeGroupToApplicationsMap.put(cartridgeGroupName, applicationNames);
+    		}
+    		applicationNames.add(applicationName);
+    	}
+    }
+    
+    public void removeUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames) {
+    	if(cartridgeGroupNames == null) {
+    		return;
+    	}
+    	
+    	for(String cartridgeGroupName : cartridgeGroupNames) {
+    		Set<String> applicationNames = null;
+    		if(cartridgeGroupToApplicationsMap.containsKey(cartridgeGroupName)) {
+    			applicationNames = cartridgeGroupToApplicationsMap.get(cartridgeGroupName);
+    			// Remove current application name
+    			applicationNames.remove(applicationName);
+    			// Remove entry if there are no more cartridge group names for that cartridge type
+    			if (applicationNames.isEmpty()) {
+    				applicationNames = null;
+    				cartridgeGroupToApplicationsMap.remove(cartridgeGroupName);
+    			}
+    		} 
+    	}
+    }
+    
+    public boolean isCartridgeGroupIncludedInApplications(String cartridgeGroupName) {
+    	if(cartridgeGroupToApplicationsMap.containsKey(cartridgeGroupName)) {
+    		if(!cartridgeGroupToApplicationsMap.get(cartridgeGroupName).isEmpty()) {
+        		return true;
+    		}
+    		return false;
+    	}
+    	return false;
+    }
+    
+    private void updateContextFromRegistry() {
+        if ((!isClustered()) || (isCoordinator())) {
+            try {
+                Object dataObj = RegistryManager.getInstance().read(DATA_RESOURCE);
+                if (dataObj != null) {
+                    if (dataObj instanceof StratosManagerContext) {
+                        StratosManagerContext serializedObj = (StratosManagerContext) dataObj;
+
+                        copyMap(serializedObj.cartridgeTypeToCartridgeGroupsMap, cartridgeTypeToCartridgeGroupsMap);
+                        copyMap(serializedObj.cartridgeTypeToApplicationsMap, cartridgeTypeToApplicationsMap);
+                        copyMap(serializedObj.cartridgeGroupToCartridgeSubGroupsMap, cartridgeGroupToCartridgeSubGroupsMap);
+                        copyMap(serializedObj.cartridgeGroupToApplicationsMap, cartridgeGroupToApplicationsMap);
+
+                        if (log.isDebugEnabled()) {
+                            log.debug("Stratos Manager context is read from the registry");
+                        }
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Stratos Manager context could not be found in the registry");
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                String msg = "Unable to read Stratos Manager context from the registry. " +
+                        "Hence, any historical data will not be reflected";
+                log.warn(msg, e);
+            }
+        }
+    }
+
+    private void copyMap(Map sourceMap, Map destinationMap) {
+        for(Object key : sourceMap.keySet()) {
+            destinationMap.put(key, sourceMap.get(key));
+        }
+    }
+    
+    public void persist() {
+        if ((!isClustered()) || (isCoordinator())) {
+            try {
+                RegistryManager.getInstance().persist(DATA_RESOURCE, this);
+            } catch (RegistryException e) {
+                log.error("Could not persist cloud controller context in registry", e);
+            }
+        }
     }
 }

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/context/StratosManagerContext.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/context/StratosManagerContext.java
@@ -40,8 +40,6 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
  */
 public class StratosManagerContext implements Serializable {
 
-	
-
 	private static volatile StratosManagerContext instance;
     
     private static final String SM_CARTRIDGE_TYPE_TO_CARTIDGE_GROUPS_MAP = "SM_CARTRIDGE_TYPE_TO_CARTIDGE_GROUPS_MAP";
@@ -191,8 +189,8 @@ public class StratosManagerContext implements Serializable {
     }
     
     public boolean isCartridgeIncludedInCartridgeGroups(String cartridgeName) {
-    	if(cartridgeTypeToApplicationsMap.containsKey(cartridgeName)) {
-    		if(!cartridgeTypeToApplicationsMap.get(cartridgeName).isEmpty()) {
+    	if(cartridgeTypeToCartridgeGroupsMap.containsKey(cartridgeName)) {
+    		if(!cartridgeTypeToCartridgeGroupsMap.get(cartridgeName).isEmpty()) {
         		return true;
     		}
     		return false;
@@ -255,7 +253,7 @@ public class StratosManagerContext implements Serializable {
     	for(String cartridgeGroupName : cartridgeGroupNames) {
     		Set<String> cartridgeSubGroupNames = null;
     		if(cartridgeGroupToCartridgeSubGroupsMap.containsKey(cartridgeGroupName)) {
-    			cartridgeSubGroupNames = cartridgeTypeToCartridgeGroupsMap.get(cartridgeGroupName);
+    			cartridgeSubGroupNames = cartridgeGroupToCartridgeSubGroupsMap.get(cartridgeGroupName);
     		} else {
     			cartridgeSubGroupNames = new HashSet<String>();
     			cartridgeGroupToCartridgeSubGroupsMap.put(cartridgeSubGroupName, cartridgeSubGroupNames);

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/internal/ServiceReferenceHolder.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/internal/ServiceReferenceHolder.java
@@ -22,6 +22,7 @@ package org.apache.stratos.manager.internal;
 import com.hazelcast.core.HazelcastInstance;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.stratos.common.clustering.DistributedObjectProvider;
 import org.wso2.carbon.ntask.core.service.TaskService;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -40,6 +41,7 @@ public class ServiceReferenceHolder {
     private TaskService taskService;
     private HazelcastInstance hazelcastInstance;
     private AxisConfiguration axisConfiguration;
+    private DistributedObjectProvider distributedObjectProvider;
 
     private ServiceReferenceHolder() {       }
 
@@ -111,4 +113,13 @@ public class ServiceReferenceHolder {
     public AxisConfiguration getAxisConfiguration() {
         return axisConfiguration;
     }
+    
+    public void setDistributedObjectProvider(DistributedObjectProvider distributedObjectProvider) {
+        this.distributedObjectProvider = distributedObjectProvider;
+    }
+
+    public DistributedObjectProvider getDistributedObjectProvider() {
+        return distributedObjectProvider;
+    }
+    
 }

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/internal/StratosManagerServiceComponent.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/internal/StratosManagerServiceComponent.java
@@ -18,19 +18,21 @@
  */
 package org.apache.stratos.manager.internal;
 
-import com.hazelcast.core.HazelcastInstance;
+import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.stratos.common.clustering.DistributedObjectProvider;
 import org.apache.stratos.common.threading.StratosThreadPool;
 import org.apache.stratos.manager.context.StratosManagerContext;
+import org.apache.stratos.manager.messaging.publisher.TenantEventPublisher;
 import org.apache.stratos.manager.messaging.publisher.synchronizer.ApplicationSignUpSynchronizerTask;
+import org.apache.stratos.manager.messaging.publisher.synchronizer.SynchronizerTaskScheduler;
 import org.apache.stratos.manager.messaging.publisher.synchronizer.TenantSynzhronizerTask;
 import org.apache.stratos.manager.messaging.receiver.StratosManagerApplicationEventReceiver;
 import org.apache.stratos.manager.messaging.receiver.StratosManagerInstanceStatusEventReceiver;
-import org.apache.stratos.manager.user.management.TenantUserRoleManager;
-import org.apache.stratos.manager.messaging.publisher.TenantEventPublisher;
-import org.apache.stratos.manager.messaging.publisher.synchronizer.SynchronizerTaskScheduler;
 import org.apache.stratos.manager.messaging.receiver.StratosManagerTopologyEventReceiver;
+import org.apache.stratos.manager.user.management.TenantUserRoleManager;
 import org.apache.stratos.manager.user.management.exception.UserManagerException;
 import org.apache.stratos.manager.utils.CartridgeConfigFileReader;
 import org.apache.stratos.manager.utils.StratosManagerConstants;
@@ -46,7 +48,7 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
-import java.util.concurrent.ExecutorService;
+import com.hazelcast.core.HazelcastInstance;
 
 /**
  * @scr.component name="org.wso2.carbon.hosting.mgt.internal.StratosManagerServiceComponent"
@@ -69,6 +71,8 @@ import java.util.concurrent.ExecutorService;
  * @scr.reference name="ntask.component" interface="org.wso2.carbon.ntask.core.service.TaskService"
  *                cardinality="1..1" policy="dynamic" bind="setTaskService"
  *                unbind="unsetTaskService"
+ * @scr.reference name="distributedObjectProvider" interface="org.apache.stratos.common.clustering.DistributedObjectProvider"
+ *                cardinality="1..1" policy="dynamic" bind="setDistributedObjectProvider" unbind="unsetDistributedObjectProvider"
  */
 public class StratosManagerServiceComponent {
 
@@ -276,6 +280,14 @@ public class StratosManagerServiceComponent {
             log.debug("Un-setting the task service");
         }
         ServiceReferenceHolder.getInstance().setTaskService(null);
+    }
+    
+    protected void setDistributedObjectProvider(DistributedObjectProvider distributedObjectProvider) {
+        ServiceReferenceHolder.getInstance().setDistributedObjectProvider(distributedObjectProvider);
+    }
+
+    protected void unsetDistributedObjectProvider(DistributedObjectProvider distributedObjectProvider) {
+        ServiceReferenceHolder.getInstance().setDistributedObjectProvider(null);
     }
 
     protected void deactivate(ComponentContext context) {

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/services/StratosManagerService.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/services/StratosManagerService.java
@@ -19,6 +19,8 @@
 
 package org.apache.stratos.manager.services;
 
+import java.util.List;
+
 import org.apache.stratos.messaging.domain.application.signup.ApplicationSignUp;
 import org.apache.stratos.manager.exception.ApplicationSignUpException;
 import org.apache.stratos.manager.exception.ArtifactDistributionCoordinatorException;
@@ -98,4 +100,84 @@ public interface StratosManagerService {
      * @throws DomainMappingException
      */
     public void removeDomainMapping(String applicationId, int tenantId, String domainName) throws DomainMappingException;
+    
+    /**
+     * Adds the used cartridges in cartridge groups to cache structure.
+     *
+     * @param cartridgeGroupName the cartridge group name
+     * @param cartridgeNames the cartridge names
+     */
+    public void addUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames);
+    
+    /**
+     * Removes the used cartridges in cartridge groups from cache structure.
+     *
+     * @param cartridgeGroupName the cartridge group name
+     * @param cartridgeNames the cartridge names
+     */
+    public void removeUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames);
+    
+    /**
+     * Adds the used cartridges in applications to cache structure.
+     *
+     * @param applicationName the application name
+     * @param cartridgeNames the cartridge names
+     */
+    public void addUsedCartridgesInApplications(String applicationName, String[] cartridgeNames);
+    
+    /**
+     * Removes the used cartridges in applications from cache structure.
+     *
+     * @param applicationName the application name
+     * @param cartridgeNames the cartridge names
+     */
+    public void removeUsedCartridgesInApplications(String applicationName, String[] cartridgeNames);
+    
+    /**
+     * Verifies whether a cartridge can be removed.
+     *
+     * @param cartridgeName the cartridge name
+     * @return true, if successful
+     */
+    public boolean canCartridgeBeRemoved(String cartridgeName);
+    
+    /**
+     * Adds the used cartridge groups in cartridge sub groups to cache structure.
+     *
+     * @param cartridgeSubGroupName the cartridge sub group name
+     * @param cartridgeGroupNames the cartridge group names
+     */
+    public void addUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames);
+    
+    /**
+     * Removes the used cartridge groups in cartridge sub groups from cache structure.
+     *
+     * @param cartridgeSubGroupName the cartridge sub group name
+     * @param cartridgeGroupNames the cartridge group names
+     */
+    public void removeUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames);
+    
+    /**
+     * Adds the used cartridge groups in applications to cache structure.
+     *
+     * @param applicationName the application name
+     * @param cartridgeGroupNames the cartridge group names
+     */
+    public void addUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames);
+    
+    /**
+     * Removes the used cartridge groups in applications from cache structure.
+     *
+     * @param applicationName the application name
+     * @param cartridgeGroupNames the cartridge group names
+     */
+    public void removeUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames);
+    
+    /**
+     * Verifies whether a cartridge group can be removed.
+     *
+     * @param cartridgeGroupName the cartridge group name
+     * @return true, if successful
+     */
+    public boolean canCartirdgeGroupBeRemoved(String cartridgeGroupName);
 }

--- a/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/services/impl/StratosManagerServiceImpl.java
+++ b/components/org.apache.stratos.manager/src/main/java/org/apache/stratos/manager/services/impl/StratosManagerServiceImpl.java
@@ -19,24 +19,23 @@
 
 package org.apache.stratos.manager.services.impl;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import java.util.concurrent.locks.Lock;
+
 import org.apache.stratos.manager.components.ApplicationSignUpHandler;
 import org.apache.stratos.manager.components.ArtifactDistributionCoordinator;
 import org.apache.stratos.manager.components.DomainMappingHandler;
-import org.apache.stratos.messaging.domain.application.signup.ApplicationSignUp;
+import org.apache.stratos.manager.context.StratosManagerContext;
 import org.apache.stratos.manager.exception.ApplicationSignUpException;
 import org.apache.stratos.manager.exception.ArtifactDistributionCoordinatorException;
 import org.apache.stratos.manager.exception.DomainMappingException;
 import org.apache.stratos.manager.services.StratosManagerService;
+import org.apache.stratos.messaging.domain.application.signup.ApplicationSignUp;
 import org.apache.stratos.messaging.domain.application.signup.DomainMapping;
 
 /**
  * Stratos manager service implementation.
  */
 public class StratosManagerServiceImpl implements StratosManagerService {
-
-    private static final Log log = LogFactory.getLog(StratosManagerServiceImpl.class);
 
     private ApplicationSignUpHandler signUpHandler;
     private ArtifactDistributionCoordinator artifactDistributionCoordinator;
@@ -91,5 +90,135 @@ public class StratosManagerServiceImpl implements StratosManagerService {
     @Override
     public void removeDomainMapping(String applicationId, int tenantId, String domainName) throws DomainMappingException {
         domainMappingHandler.removeDomainMapping(applicationId, tenantId, domainName);
+    }
+    
+    @Override
+    public void addUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgesCartridgeGroupsWriteLock();
+	    	StratosManagerContext.getInstance().addUsedCartridgesInCartridgeGroups(cartridgeGroupName, cartridgeNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public void removeUsedCartridgesInCartridgeGroups(String cartridgeGroupName, String[] cartridgeNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgesCartridgeGroupsWriteLock();
+	    	StratosManagerContext.getInstance().removeUsedCartridgesInCartridgeGroups(cartridgeGroupName, cartridgeNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public void addUsedCartridgesInApplications(String applicationName, String[] cartridgeNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgesApplicationsWriteLock();
+	    	StratosManagerContext.getInstance().addUsedCartridgesInApplications(applicationName, cartridgeNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public void removeUsedCartridgesInApplications(String applicationName, String[] cartridgeNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgesApplicationsWriteLock();
+	    	StratosManagerContext.getInstance().removeUsedCartridgesInApplications(applicationName, cartridgeNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public boolean canCartridgeBeRemoved(String cartridgeName) {
+    	if (StratosManagerContext.getInstance().isCartridgeIncludedInCartridgeGroups(cartridgeName) || 
+    			StratosManagerContext.getInstance().isCartridgeIncludedInApplications(cartridgeName)) {
+    		return false;
+    	}
+    	return true;
+    }
+    
+    @Override
+    public void addUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgeGroupsCartridgeSubGroupsWriteLock();
+	    	StratosManagerContext.getInstance().addUsedCartridgeGroupsInCartridgeSubGroups(cartridgeSubGroupName, cartridgeGroupNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public void removeUsedCartridgeGroupsInCartridgeSubGroups(String cartridgeSubGroupName, String[] cartridgeGroupNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgeGroupsCartridgeSubGroupsWriteLock();
+	    	StratosManagerContext.getInstance().removeUsedCartridgeGroupsInCartridgeSubGroups(cartridgeSubGroupName, cartridgeGroupNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public void addUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgeGroupsApplicationsWriteLock();
+	    	StratosManagerContext.getInstance().addUsedCartridgeGroupsInApplications(applicationName, cartridgeGroupNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public void removeUsedCartridgeGroupsInApplications(String applicationName, String[] cartridgeGroupNames) {
+    	Lock lock = null;
+    	try {
+	    	lock = StratosManagerContext.getInstance().acquireCartridgeGroupsApplicationsWriteLock();
+	    	StratosManagerContext.getInstance().removeUsedCartridgeGroupsInApplications(applicationName, cartridgeGroupNames);
+	    	StratosManagerContext.getInstance().persist();
+    	} finally {
+            if (lock != null) {
+            	StratosManagerContext.getInstance().releaseWriteLock(lock);
+            }
+        }
+    }
+    
+    @Override
+    public boolean canCartirdgeGroupBeRemoved(String cartridgeGroupName) {
+    	if(StratosManagerContext.getInstance().isCartridgeGroupIncludedInCartridgeSubGroups(cartridgeGroupName) ||
+    			StratosManagerContext.getInstance().isCartridgeGroupIncludedInApplications(cartridgeGroupName)) {
+    		return false;
+    	}
+    	return true;
     }
 }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -37,11 +37,13 @@ import org.apache.stratos.cloud.controller.stub.domain.Volume;
 import org.apache.stratos.common.beans.PropertyBean;
 import org.apache.stratos.common.beans.application.ApplicationBean;
 import org.apache.stratos.common.beans.application.GroupBean;
+import org.apache.stratos.common.beans.application.GroupReferenceBean;
 import org.apache.stratos.common.beans.application.domain.mapping.ApplicationDomainMappingsBean;
 import org.apache.stratos.common.beans.application.domain.mapping.DomainMappingBean;
 import org.apache.stratos.common.beans.application.signup.ApplicationSignUpBean;
 import org.apache.stratos.common.beans.artifact.repository.GitNotificationPayloadBean;
 import org.apache.stratos.common.beans.cartridge.CartridgeBean;
+import org.apache.stratos.common.beans.cartridge.CartridgeReferenceBean;
 import org.apache.stratos.common.beans.cartridge.PersistenceBean;
 import org.apache.stratos.common.beans.cartridge.VolumeBean;
 import org.apache.stratos.common.beans.kubernetes.KubernetesClusterBean;
@@ -158,9 +160,18 @@ public class StratosApiV41Utils {
                 log.debug(String.format("Removing cartridge: [cartridge-type] %s ", cartridgeType));
             }
 
-            CloudControllerServiceClient cloudControllerServiceClient = CloudControllerServiceClient.getInstance();
+            CloudControllerServiceClient cloudControllerServiceClient = getCloudControllerServiceClient();
             if(cloudControllerServiceClient.getCartridgeInfo(cartridgeType) == null) {
                 throw new RuntimeException("Cartridge not found: [cartridge-type] " + cartridgeType);
+            }
+            
+            StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
+            
+            // Validate whether cartridge can be removed
+            if(!smServiceClient.canCartridgeBeRemoved(cartridgeType)) {
+            	String message = "Cannot remove cartridge : [cartridge-type] " + cartridgeType + " since it is used in another cartridge group or an application";
+                log.error(message);
+                throw new RestAPIException(message);
             }
             cloudControllerServiceClient.removeCartridge(cartridgeType);
 
@@ -510,6 +521,17 @@ public class StratosApiV41Utils {
             throw new RestAPIException(errorMsg, axisFault);
         }
     }
+    
+    private static StratosManagerServiceClient getStratosManagerServiceClient() throws RestAPIException {
+        try {
+            return StratosManagerServiceClient.getInstance();
+        } catch (AxisFault axisFault) {
+            String errorMsg = "Error while getting StratosManagerServiceClient instance to connect to the "
+                    + "Stratos Manager. Cause: " + axisFault.getMessage();
+            log.error(errorMsg, axisFault);
+            throw new RestAPIException(errorMsg, axisFault);
+        }
+    }
 
     // Util methods for Autoscaling policies
 
@@ -650,15 +672,18 @@ public class StratosApiV41Utils {
             if (serviceGroupDefinition == null) {
                 throw new RuntimeException("Service Group definition is null");
             }
+            
+            List<String> cartridgeTypes = null;
+            List<String> groupNames = null;
 
             // if any cartridges are specified in the group, they should be already deployed
             if (serviceGroupDefinition.getCartridges() != null) {
-
+            	
                 if (log.isDebugEnabled()) {
                     log.debug("checking cartridges in cartridge group " + serviceGroupDefinition.getName());
                 }
 
-                List<String> cartridgeTypes = serviceGroupDefinition.getCartridges();
+                cartridgeTypes = serviceGroupDefinition.getCartridges();
 
                 Set<String> duplicates = findDuplicates(cartridgeTypes);
                 if (duplicates.size() > 0) {
@@ -672,13 +697,7 @@ public class StratosApiV41Utils {
                     throw new RestAPIException("Invalid Service Group definition, duplicate cartridges defined:" + buf.toString());
                 }
 
-                CloudControllerServiceClient ccServiceClient = null;
-
-                try {
-                    ccServiceClient = CloudControllerServiceClient.getInstance();
-                } catch (AxisFault axisFault) {
-                    throw new RestAPIException(axisFault);
-                }
+                CloudControllerServiceClient ccServiceClient = getCloudControllerServiceClient();
 
                 for (String cartridgeType : cartridgeTypes) {
                     try {
@@ -702,7 +721,7 @@ public class StratosApiV41Utils {
                 }
 
                 List<GroupBean> groupDefinitions = serviceGroupDefinition.getGroups();
-                List<String> groupNames = new ArrayList<String>();
+                groupNames = new ArrayList<String>();
                 for (GroupBean groupList : groupDefinitions) {
                     groupNames.add(groupList.getName());
                 }
@@ -718,13 +737,23 @@ public class StratosApiV41Utils {
                         log.debug("duplicate subGroups defined: " + buf.toString());
                     }
                     throw new RestAPIException("Invalid Service Group definition, duplicate subGroups defined:" + buf.toString());
-                }
+                } 
             }
 
             ServiceGroup serviceGroup = ObjectConverter.convertServiceGroupDefinitionToASStubServiceGroup(serviceGroupDefinition);
 
-            AutoscalerServiceClient asServiceClient = AutoscalerServiceClient.getInstance();
+            AutoscalerServiceClient asServiceClient = getAutoscalerServiceClient();
             asServiceClient.addServiceGroup(serviceGroup);
+            
+            // Add cartridge group elements to SM cache - done after service group has been added
+            StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
+            if(cartridgeTypes != null) {
+            	smServiceClient.addUsedCartridgesInCartridgeGroups(serviceGroupDefinition.getName(), (String[]) cartridgeTypes.toArray());
+            }
+            if(groupNames != null) {
+            	smServiceClient.addUsedCartridgeGroupsInCartridgeSubGroups(serviceGroupDefinition.getName(), (String[]) groupNames.toArray());
+            }
+            
         } catch (Exception e) {
             String message = "Could not add cartridge group";
             log.error(message, e);
@@ -804,9 +833,35 @@ public class StratosApiV41Utils {
             if (log.isDebugEnabled()) {
                 log.debug("Removing cartridge group: [name] " + name);
             }
-
-            AutoscalerServiceClient autoscalerServiceClient = AutoscalerServiceClient.getInstance();
-            autoscalerServiceClient.undeployServiceGroupDefinition(name);
+            
+            AutoscalerServiceClient asServiceClient = getAutoscalerServiceClient();
+            StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
+            
+            // Validate whether cartridge group can be removed
+            if(!smServiceClient.canCartirdgeGroupBeRemoved(name)) {
+            	String message = "Cannot remove cartridge group: [group-name] " + name + " since it is used in another cartridge group or an application";
+                log.error(message);
+                throw new RestAPIException(message);
+            }
+            
+            ServiceGroup serviceGroup = asServiceClient.getServiceGroup(name);
+            
+            asServiceClient.undeployServiceGroupDefinition(name);
+            
+            // Remove the dependent cartridges and cartridge groups from Stratos Manager cache - done after service group has been removed
+            if (serviceGroup.getCartridges() != null) {
+            	String[] cartridgeNames = serviceGroup.getCartridges();
+            	smServiceClient.removeUsedCartridgesInCartridgeGroups(name, cartridgeNames);
+            }
+            
+            if (serviceGroup.getGroups() != null) {
+            	ServiceGroup[] cartridgeGroups = serviceGroup.getGroups();
+            	Set<String> cartridgeGroupNames = new HashSet<String>();
+            	for(ServiceGroup cartridgeGroup : cartridgeGroups) {
+            		cartridgeGroupNames.add(cartridgeGroup.getName());
+            	}
+            	smServiceClient.removeUsedCartridgeGroupsInCartridgeSubGroups(name, (String[]) cartridgeGroupNames.toArray());
+            }
 
         } catch (Exception e) {
             throw new RestAPIException(e);
@@ -857,6 +912,33 @@ public class StratosApiV41Utils {
 
         try {
             AutoscalerServiceClient.getInstance().addApplication(applicationContext);
+            
+            // Add application elements to SM cache - done after application has been added
+            Set<String> cartridgeNames;
+            Set<String> cartridgeGroupNames;
+                        
+            StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
+            
+            List<CartridgeReferenceBean> cartridges = appDefinition.getComponents().getCartridges();
+            if(cartridges != null) {
+            	cartridgeNames = new HashSet<String>();
+            	for(CartridgeReferenceBean cartridge : cartridges) {
+            		cartridgeNames.add(cartridge.getType());
+            	}
+            	
+            	smServiceClient.addUsedCartridgesInApplications(appDefinition.getApplicationId(), (String[]) cartridgeNames.toArray());
+            }
+            
+            List<GroupReferenceBean> cartridgeGroups = appDefinition.getComponents().getGroups();
+            if(cartridgeGroups != null) {
+            	cartridgeGroupNames = new HashSet<String>();
+            	for(GroupReferenceBean cartridgeGroup : cartridgeGroups) {
+            		cartridgeGroupNames.add(cartridgeGroup.getName());
+            	}
+            	
+            	smServiceClient.addUsedCartridgeGroupsInApplications(appDefinition.getApplicationId(), (String[]) cartridgeGroupNames.toArray());
+            }
+            
         } catch (AutoscalerServiceApplicationDefinitionExceptionException e) {
             throw new RestAPIException(e);
         } catch (RemoteException e) {
@@ -915,7 +997,36 @@ public class StratosApiV41Utils {
     public static void removeApplication(String applicationId) throws RestAPIException {
 
         try {
-            AutoscalerServiceClient.getInstance().deleteApplication(applicationId);
+        	AutoscalerServiceClient asServiceClient = getAutoscalerServiceClient();
+        	
+        	ApplicationBean application = ObjectConverter.convertStubApplicationContextToApplicationDefinition(asServiceClient.getApplication(applicationId));
+        	asServiceClient.deleteApplication(applicationId);
+            
+            // Remove application elements in SM cache - done after deleting
+        	Set<String> cartridgeNames;
+            Set<String> cartridgeGroupNames;
+            StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
+            
+            List<CartridgeReferenceBean> cartridges = application.getComponents().getCartridges();
+            if(cartridges != null) {
+            	cartridgeNames = new HashSet<String>();
+            	for(CartridgeReferenceBean cartridge : cartridges) {
+            		cartridgeNames.add(cartridge.getType());
+            	}
+            	
+            	smServiceClient.removeUsedCartridgesInApplications(application.getApplicationId(), (String[]) cartridgeNames.toArray());
+            }
+            
+            List<GroupReferenceBean> cartridgeGroups = application.getComponents().getGroups();
+            if(cartridgeGroups != null) {
+            	cartridgeGroupNames = new HashSet<String>();
+            	for(GroupReferenceBean cartridgeGroup : cartridgeGroups) {
+            		cartridgeGroupNames.add(cartridgeGroup.getName());
+            	}
+            	
+            	smServiceClient.removeUsedCartridgeGroupsInApplications(application.getApplicationId(), (String[]) cartridgeGroupNames.toArray());
+            }
+            
         } catch (RemoteException e) {
             String message = "Could not delete application: [application-id] " + applicationId;
             log.error(message, e);

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -674,7 +674,9 @@ public class StratosApiV41Utils {
             }
             
             List<String> cartridgeTypes = null;
+            String[] cartridgeNames = null;
             List<String> groupNames = null;
+            String[] cartridgeGroupNames = null;
 
             // if any cartridges are specified in the group, they should be already deployed
             if (serviceGroupDefinition.getCartridges() != null) {
@@ -698,13 +700,18 @@ public class StratosApiV41Utils {
                 }
 
                 CloudControllerServiceClient ccServiceClient = getCloudControllerServiceClient();
-
+                
+                cartridgeNames = new String[cartridgeTypes.size()];
+                int i=0;
                 for (String cartridgeType : cartridgeTypes) {
                     try {
                         if (ccServiceClient.getCartridgeInfo(cartridgeType) == null) {
                             // cartridge is not deployed, can't continue
                             log.error("invalid cartridge found in cartridge group " + cartridgeType);
                             throw new RestAPIException("No Cartridge Definition found with type " + cartridgeType);
+                        } else {
+                        	cartridgeNames[i] = cartridgeType;
+                        	i++;
                         }
                     } catch (RemoteException e) {
                         throw new RestAPIException(e);
@@ -722,8 +729,12 @@ public class StratosApiV41Utils {
 
                 List<GroupBean> groupDefinitions = serviceGroupDefinition.getGroups();
                 groupNames = new ArrayList<String>();
+                cartridgeGroupNames = new String[groupNames.size()];
+                int i=0;
                 for (GroupBean groupList : groupDefinitions) {
                     groupNames.add(groupList.getName());
+                    cartridgeGroupNames[i] = groupList.getName();
+                    i++;
                 }
 
                 Set<String> duplicates = findDuplicates(groupNames);
@@ -748,10 +759,10 @@ public class StratosApiV41Utils {
             // Add cartridge group elements to SM cache - done after service group has been added
             StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
             if(cartridgeTypes != null) {
-            	smServiceClient.addUsedCartridgesInCartridgeGroups(serviceGroupDefinition.getName(), (String[]) cartridgeTypes.toArray());
+            	smServiceClient.addUsedCartridgesInCartridgeGroups(serviceGroupDefinition.getName(), cartridgeNames);
             }
             if(groupNames != null) {
-            	smServiceClient.addUsedCartridgeGroupsInCartridgeSubGroups(serviceGroupDefinition.getName(), (String[]) groupNames.toArray());
+            	smServiceClient.addUsedCartridgeGroupsInCartridgeSubGroups(serviceGroupDefinition.getName(), cartridgeGroupNames);
             }
             
         } catch (Exception e) {
@@ -837,6 +848,13 @@ public class StratosApiV41Utils {
             AutoscalerServiceClient asServiceClient = getAutoscalerServiceClient();
             StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
             
+            // Check whether cartridge group exists
+            if(asServiceClient.getServiceGroup(name) == null) {
+            	String message = "Cartridge group: [group-name] " + name + " cannot be removed since it does not exist";
+                log.error(message);
+                throw new RestAPIException(message);
+            }
+            
             // Validate whether cartridge group can be removed
             if(!smServiceClient.canCartirdgeGroupBeRemoved(name)) {
             	String message = "Cannot remove cartridge group: [group-name] " + name + " since it is used in another cartridge group or an application";
@@ -856,11 +874,17 @@ public class StratosApiV41Utils {
             
             if (serviceGroup.getGroups() != null) {
             	ServiceGroup[] cartridgeGroups = serviceGroup.getGroups();
-            	Set<String> cartridgeGroupNames = new HashSet<String>();
+            	String[] cartridgeGroupNames = new String[cartridgeGroups.length];
+            	int i = 0;
             	for(ServiceGroup cartridgeGroup : cartridgeGroups) {
-            		cartridgeGroupNames.add(cartridgeGroup.getName());
+            		if(cartridgeGroup != null) {
+                		cartridgeGroupNames[i] = cartridgeGroup.getName();
+                		i++;
+            		} else {
+            			break;
+            		}
             	}
-            	smServiceClient.removeUsedCartridgeGroupsInCartridgeSubGroups(name, (String[]) cartridgeGroupNames.toArray());
+            	smServiceClient.removeUsedCartridgeGroupsInCartridgeSubGroups(name, cartridgeGroupNames);
             }
 
         } catch (Exception e) {
@@ -914,29 +938,33 @@ public class StratosApiV41Utils {
             AutoscalerServiceClient.getInstance().addApplication(applicationContext);
             
             // Add application elements to SM cache - done after application has been added
-            Set<String> cartridgeNames;
-            Set<String> cartridgeGroupNames;
+            String[] cartridgeNames;
+            String[] cartridgeGroupNames;
                         
             StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
             
             List<CartridgeReferenceBean> cartridges = appDefinition.getComponents().getCartridges();
             if(cartridges != null) {
-            	cartridgeNames = new HashSet<String>();
+            	cartridgeNames = new String[cartridges.size()];
+            	int i=0;
             	for(CartridgeReferenceBean cartridge : cartridges) {
-            		cartridgeNames.add(cartridge.getType());
+            		cartridgeNames[i] = cartridge.getType();
+            		i++;
             	}
             	
-            	smServiceClient.addUsedCartridgesInApplications(appDefinition.getApplicationId(), (String[]) cartridgeNames.toArray());
+            	smServiceClient.addUsedCartridgesInApplications(appDefinition.getApplicationId(), cartridgeNames);
             }
             
             List<GroupReferenceBean> cartridgeGroups = appDefinition.getComponents().getGroups();
             if(cartridgeGroups != null) {
-            	cartridgeGroupNames = new HashSet<String>();
+            	cartridgeGroupNames = new String[cartridgeGroups.size()];
+            	int i=0;
             	for(GroupReferenceBean cartridgeGroup : cartridgeGroups) {
-            		cartridgeGroupNames.add(cartridgeGroup.getName());
+            		cartridgeGroupNames[i] = cartridgeGroup.getName();
+            		i++;
             	}
             	
-            	smServiceClient.addUsedCartridgeGroupsInApplications(appDefinition.getApplicationId(), (String[]) cartridgeGroupNames.toArray());
+            	smServiceClient.addUsedCartridgeGroupsInApplications(appDefinition.getApplicationId(), cartridgeGroupNames);
             }
             
         } catch (AutoscalerServiceApplicationDefinitionExceptionException e) {
@@ -1003,28 +1031,32 @@ public class StratosApiV41Utils {
         	asServiceClient.deleteApplication(applicationId);
             
             // Remove application elements in SM cache - done after deleting
-        	Set<String> cartridgeNames;
-            Set<String> cartridgeGroupNames;
+        	String[] cartridgeNames;
+            String[] cartridgeGroupNames;
             StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
             
             List<CartridgeReferenceBean> cartridges = application.getComponents().getCartridges();
             if(cartridges != null) {
-            	cartridgeNames = new HashSet<String>();
+            	cartridgeNames = new String[cartridges.size()];
+            	int i=0;
             	for(CartridgeReferenceBean cartridge : cartridges) {
-            		cartridgeNames.add(cartridge.getType());
+            		cartridgeNames[i] = cartridge.getType();
+            		i++;
             	}
             	
-            	smServiceClient.removeUsedCartridgesInApplications(application.getApplicationId(), (String[]) cartridgeNames.toArray());
+            	smServiceClient.removeUsedCartridgesInApplications(application.getApplicationId(), cartridgeNames);
             }
             
             List<GroupReferenceBean> cartridgeGroups = application.getComponents().getGroups();
             if(cartridgeGroups != null) {
-            	cartridgeGroupNames = new HashSet<String>();
+            	cartridgeGroupNames = new String[cartridgeGroups.size()];
+            	int i=0;
             	for(GroupReferenceBean cartridgeGroup : cartridgeGroups) {
-            		cartridgeGroupNames.add(cartridgeGroup.getName());
+            		cartridgeGroupNames[i] = cartridgeGroup.getName();
+            		i++;
             	}
             	
-            	smServiceClient.removeUsedCartridgeGroupsInApplications(application.getApplicationId(), (String[]) cartridgeGroupNames.toArray());
+            	smServiceClient.removeUsedCartridgeGroupsInApplications(application.getApplicationId(), cartridgeGroupNames);
             }
             
         } catch (RemoteException e) {

--- a/service-stubs/org.apache.stratos.manager.service.stub/src/main/resources/StratosManagerService.wsdl
+++ b/service-stubs/org.apache.stratos.manager.service.stub/src/main/resources/StratosManagerService.wsdl
@@ -1,6 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?><wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ns="http://impl.services.manager.stratos.apache.org" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:ax23="http://signup.application.domain.messaging.stratos.apache.org/xsd" xmlns:ax21="http://exception.manager.stratos.apache.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://impl.services.manager.stratos.apache.org">
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://org.apache.axis2/xsd" xmlns:ns="http://impl.services.manager.stratos.apache.org" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:ax23="http://signup.application.domain.messaging.stratos.apache.org/xsd" xmlns:ax21="http://exception.manager.stratos.apache.org/xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" targetNamespace="http://impl.services.manager.stratos.apache.org">
     <wsdl:types>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://signup.application.domain.messaging.stratos.apache.org/xsd">
+            <xs:complexType name="DomainMapping">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="clusterId" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="contextPath" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="domainName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="serviceName" nillable="true" type="xs:string"/>
+                    <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
+                </xs:sequence>
+            </xs:complexType>
             <xs:complexType name="ApplicationSignUp">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
@@ -20,68 +31,39 @@
                     <xs:element minOccurs="0" name="repoUsername" nillable="true" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="DomainMapping">
-                <xs:sequence>
-                    <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="clusterId" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="contextPath" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="domainName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="serviceName" nillable="true" type="xs:string"/>
-                    <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
-                </xs:sequence>
-            </xs:complexType>
         </xs:schema>
         <xs:schema xmlns:ax24="http://signup.application.domain.messaging.stratos.apache.org/xsd" xmlns:ax22="http://exception.manager.stratos.apache.org/xsd" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://impl.services.manager.stratos.apache.org">
             <xs:import namespace="http://exception.manager.stratos.apache.org/xsd"/>
             <xs:import namespace="http://signup.application.domain.messaging.stratos.apache.org/xsd"/>
-            <xs:element name="StratosManagerServiceApplicationSignUpException">
+            <xs:element name="removeUsedCartridgesInCartridgeGroups">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="ApplicationSignUpException" nillable="true" type="ax21:ApplicationSignUpException"/>
+                        <xs:element minOccurs="0" name="cartridgeGroupName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeNames" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="addApplicationSignUp">
+            <xs:element name="removeUsedCartridgesInApplications">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationSignUp" nillable="true" type="ax23:ApplicationSignUp"/>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeNames" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="removeApplicationSignUp">
+            <xs:element name="removeUsedCartridgeGroupsInCartridgeSubGroups">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
+                        <xs:element minOccurs="0" name="cartridgeSubGroupName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeGroupNames" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="getApplicationSignUp">
+            <xs:element name="removeUsedCartridgeGroupsInApplications">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationSignUpResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="return" nillable="true" type="ax23:ApplicationSignUp"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationSignUps">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getApplicationSignUpsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:ApplicationSignUp"/>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeGroupNames" nillable="true" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -89,21 +71,6 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element minOccurs="0" name="DomainMappingException" nillable="true" type="ax21:DomainMappingException"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDomainMappings">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
-                        <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="getDomainMappingsResponse">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:DomainMapping"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -116,10 +83,18 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="addDomainMapping">
+            <xs:element name="StratosManagerServiceApplicationSignUpException">
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element minOccurs="0" name="domainMapping" nillable="true" type="ax23:DomainMapping"/>
+                        <xs:element minOccurs="0" name="ApplicationSignUpException" nillable="true" type="ax21:ApplicationSignUpException"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="removeApplicationSignUp">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -145,12 +120,130 @@
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="getDomainMappings">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getDomainMappingsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:DomainMapping"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationSignUps">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationSignUpsResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="return" nillable="true" type="ax23:ApplicationSignUp"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationSignUp">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationId" nillable="true" type="xs:string"/>
+                        <xs:element minOccurs="0" name="tenantId" type="xs:int"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="getApplicationSignUpResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" nillable="true" type="ax23:ApplicationSignUp"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="canCartridgeBeRemoved">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="cartridgeName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="canCartridgeBeRemovedResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="canCartirdgeGroupBeRemoved">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="cartridgeGroupName" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="canCartirdgeGroupBeRemovedResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="return" type="xs:boolean"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addUsedCartridgesInCartridgeGroups">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="cartridgeGroupName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeNames" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addUsedCartridgesInApplications">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeNames" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addUsedCartridgeGroupsInCartridgeSubGroups">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="cartridgeSubGroupName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeGroupNames" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addUsedCartridgeGroupsInApplications">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationName" nillable="true" type="xs:string"/>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="cartridgeGroupNames" nillable="true" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addDomainMapping">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="domainMapping" nillable="true" type="ax23:DomainMapping"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="addApplicationSignUp">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element minOccurs="0" name="applicationSignUp" nillable="true" type="ax23:ApplicationSignUp"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:schema>
         <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://exception.manager.stratos.apache.org/xsd">
-            <xs:complexType name="ApplicationSignUpException">
+            <xs:complexType name="DomainMappingException">
                 <xs:sequence/>
             </xs:complexType>
-            <xs:complexType name="DomainMappingException">
+            <xs:complexType name="ApplicationSignUpException">
                 <xs:sequence/>
             </xs:complexType>
             <xs:complexType name="ArtifactDistributionCoordinatorException">
@@ -158,14 +251,14 @@
             </xs:complexType>
         </xs:schema>
     </wsdl:types>
-    <wsdl:message name="getDomainMappingsRequest">
-        <wsdl:part name="parameters" element="ns:getDomainMappings"/>
+    <wsdl:message name="canCartridgeBeRemovedRequest">
+        <wsdl:part name="parameters" element="ns:canCartridgeBeRemoved"/>
     </wsdl:message>
-    <wsdl:message name="getDomainMappingsResponse">
-        <wsdl:part name="parameters" element="ns:getDomainMappingsResponse"/>
+    <wsdl:message name="canCartridgeBeRemovedResponse">
+        <wsdl:part name="parameters" element="ns:canCartridgeBeRemovedResponse"/>
     </wsdl:message>
-    <wsdl:message name="StratosManagerServiceDomainMappingException">
-        <wsdl:part name="parameters" element="ns:StratosManagerServiceDomainMappingException"/>
+    <wsdl:message name="addUsedCartridgeGroupsInApplicationsRequest">
+        <wsdl:part name="parameters" element="ns:addUsedCartridgeGroupsInApplications"/>
     </wsdl:message>
     <wsdl:message name="getApplicationSignUpsRequest">
         <wsdl:part name="parameters" element="ns:getApplicationSignUps"/>
@@ -176,14 +269,44 @@
     <wsdl:message name="StratosManagerServiceApplicationSignUpException">
         <wsdl:part name="parameters" element="ns:StratosManagerServiceApplicationSignUpException"/>
     </wsdl:message>
+    <wsdl:message name="getDomainMappingsRequest">
+        <wsdl:part name="parameters" element="ns:getDomainMappings"/>
+    </wsdl:message>
+    <wsdl:message name="getDomainMappingsResponse">
+        <wsdl:part name="parameters" element="ns:getDomainMappingsResponse"/>
+    </wsdl:message>
+    <wsdl:message name="StratosManagerServiceDomainMappingException">
+        <wsdl:part name="parameters" element="ns:StratosManagerServiceDomainMappingException"/>
+    </wsdl:message>
     <wsdl:message name="notifyArtifactUpdatedEventForSignUpRequest">
         <wsdl:part name="parameters" element="ns:notifyArtifactUpdatedEventForSignUp"/>
     </wsdl:message>
     <wsdl:message name="StratosManagerServiceArtifactDistributionCoordinatorException">
         <wsdl:part name="parameters" element="ns:StratosManagerServiceArtifactDistributionCoordinatorException"/>
     </wsdl:message>
+    <wsdl:message name="removeUsedCartridgesInApplicationsRequest">
+        <wsdl:part name="parameters" element="ns:removeUsedCartridgesInApplications"/>
+    </wsdl:message>
+    <wsdl:message name="addUsedCartridgesInCartridgeGroupsRequest">
+        <wsdl:part name="parameters" element="ns:addUsedCartridgesInCartridgeGroups"/>
+    </wsdl:message>
+    <wsdl:message name="removeUsedCartridgeGroupsInCartridgeSubGroupsRequest">
+        <wsdl:part name="parameters" element="ns:removeUsedCartridgeGroupsInCartridgeSubGroups"/>
+    </wsdl:message>
+    <wsdl:message name="addUsedCartridgeGroupsInCartridgeSubGroupsRequest">
+        <wsdl:part name="parameters" element="ns:addUsedCartridgeGroupsInCartridgeSubGroups"/>
+    </wsdl:message>
+    <wsdl:message name="removeUsedCartridgeGroupsInApplicationsRequest">
+        <wsdl:part name="parameters" element="ns:removeUsedCartridgeGroupsInApplications"/>
+    </wsdl:message>
+    <wsdl:message name="removeUsedCartridgesInCartridgeGroupsRequest">
+        <wsdl:part name="parameters" element="ns:removeUsedCartridgesInCartridgeGroups"/>
+    </wsdl:message>
     <wsdl:message name="addDomainMappingRequest">
         <wsdl:part name="parameters" element="ns:addDomainMapping"/>
+    </wsdl:message>
+    <wsdl:message name="addUsedCartridgesInApplicationsRequest">
+        <wsdl:part name="parameters" element="ns:addUsedCartridgesInApplications"/>
     </wsdl:message>
     <wsdl:message name="removeApplicationSignUpRequest">
         <wsdl:part name="parameters" element="ns:removeApplicationSignUp"/>
@@ -193,6 +316,12 @@
     </wsdl:message>
     <wsdl:message name="notifyArtifactUpdatedEventForRepositoryRequest">
         <wsdl:part name="parameters" element="ns:notifyArtifactUpdatedEventForRepository"/>
+    </wsdl:message>
+    <wsdl:message name="canCartirdgeGroupBeRemovedRequest">
+        <wsdl:part name="parameters" element="ns:canCartirdgeGroupBeRemoved"/>
+    </wsdl:message>
+    <wsdl:message name="canCartirdgeGroupBeRemovedResponse">
+        <wsdl:part name="parameters" element="ns:canCartirdgeGroupBeRemovedResponse"/>
     </wsdl:message>
     <wsdl:message name="getApplicationSignUpRequest">
         <wsdl:part name="parameters" element="ns:getApplicationSignUp"/>
@@ -204,23 +333,51 @@
         <wsdl:part name="parameters" element="ns:addApplicationSignUp"/>
     </wsdl:message>
     <wsdl:portType name="StratosManagerServicePortType">
-        <wsdl:operation name="getDomainMappings">
-            <wsdl:input message="ns:getDomainMappingsRequest" wsaw:Action="urn:getDomainMappings"/>
-            <wsdl:output message="ns:getDomainMappingsResponse" wsaw:Action="urn:getDomainMappingsResponse"/>
-            <wsdl:fault message="ns:StratosManagerServiceDomainMappingException" name="StratosManagerServiceDomainMappingException" wsaw:Action="urn:getDomainMappingsStratosManagerServiceDomainMappingException"/>
+        <wsdl:operation name="canCartridgeBeRemoved">
+            <wsdl:input message="ns:canCartridgeBeRemovedRequest" wsaw:Action="urn:canCartridgeBeRemoved"/>
+            <wsdl:output message="ns:canCartridgeBeRemovedResponse" wsaw:Action="urn:canCartridgeBeRemovedResponse"/>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInApplications">
+            <wsdl:input message="ns:addUsedCartridgeGroupsInApplicationsRequest" wsaw:Action="urn:addUsedCartridgeGroupsInApplications"/>
         </wsdl:operation>
         <wsdl:operation name="getApplicationSignUps">
             <wsdl:input message="ns:getApplicationSignUpsRequest" wsaw:Action="urn:getApplicationSignUps"/>
             <wsdl:output message="ns:getApplicationSignUpsResponse" wsaw:Action="urn:getApplicationSignUpsResponse"/>
             <wsdl:fault message="ns:StratosManagerServiceApplicationSignUpException" name="StratosManagerServiceApplicationSignUpException" wsaw:Action="urn:getApplicationSignUpsStratosManagerServiceApplicationSignUpException"/>
         </wsdl:operation>
+        <wsdl:operation name="getDomainMappings">
+            <wsdl:input message="ns:getDomainMappingsRequest" wsaw:Action="urn:getDomainMappings"/>
+            <wsdl:output message="ns:getDomainMappingsResponse" wsaw:Action="urn:getDomainMappingsResponse"/>
+            <wsdl:fault message="ns:StratosManagerServiceDomainMappingException" name="StratosManagerServiceDomainMappingException" wsaw:Action="urn:getDomainMappingsStratosManagerServiceDomainMappingException"/>
+        </wsdl:operation>
         <wsdl:operation name="notifyArtifactUpdatedEventForSignUp">
             <wsdl:input message="ns:notifyArtifactUpdatedEventForSignUpRequest" wsaw:Action="urn:notifyArtifactUpdatedEventForSignUp"/>
             <wsdl:fault message="ns:StratosManagerServiceArtifactDistributionCoordinatorException" name="StratosManagerServiceArtifactDistributionCoordinatorException" wsaw:Action="urn:notifyArtifactUpdatedEventForSignUpStratosManagerServiceArtifactDistributionCoordinatorException"/>
         </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInApplications">
+            <wsdl:input message="ns:removeUsedCartridgesInApplicationsRequest" wsaw:Action="urn:removeUsedCartridgesInApplications"/>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInCartridgeGroups">
+            <wsdl:input message="ns:addUsedCartridgesInCartridgeGroupsRequest" wsaw:Action="urn:addUsedCartridgesInCartridgeGroups"/>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInCartridgeSubGroups">
+            <wsdl:input message="ns:removeUsedCartridgeGroupsInCartridgeSubGroupsRequest" wsaw:Action="urn:removeUsedCartridgeGroupsInCartridgeSubGroups"/>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInCartridgeSubGroups">
+            <wsdl:input message="ns:addUsedCartridgeGroupsInCartridgeSubGroupsRequest" wsaw:Action="urn:addUsedCartridgeGroupsInCartridgeSubGroups"/>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInApplications">
+            <wsdl:input message="ns:removeUsedCartridgeGroupsInApplicationsRequest" wsaw:Action="urn:removeUsedCartridgeGroupsInApplications"/>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInCartridgeGroups">
+            <wsdl:input message="ns:removeUsedCartridgesInCartridgeGroupsRequest" wsaw:Action="urn:removeUsedCartridgesInCartridgeGroups"/>
+        </wsdl:operation>
         <wsdl:operation name="addDomainMapping">
             <wsdl:input message="ns:addDomainMappingRequest" wsaw:Action="urn:addDomainMapping"/>
             <wsdl:fault message="ns:StratosManagerServiceDomainMappingException" name="StratosManagerServiceDomainMappingException" wsaw:Action="urn:addDomainMappingStratosManagerServiceDomainMappingException"/>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInApplications">
+            <wsdl:input message="ns:addUsedCartridgesInApplicationsRequest" wsaw:Action="urn:addUsedCartridgesInApplications"/>
         </wsdl:operation>
         <wsdl:operation name="removeApplicationSignUp">
             <wsdl:input message="ns:removeApplicationSignUpRequest" wsaw:Action="urn:removeApplicationSignUp"/>
@@ -233,6 +390,10 @@
         <wsdl:operation name="notifyArtifactUpdatedEventForRepository">
             <wsdl:input message="ns:notifyArtifactUpdatedEventForRepositoryRequest" wsaw:Action="urn:notifyArtifactUpdatedEventForRepository"/>
             <wsdl:fault message="ns:StratosManagerServiceArtifactDistributionCoordinatorException" name="StratosManagerServiceArtifactDistributionCoordinatorException" wsaw:Action="urn:notifyArtifactUpdatedEventForRepositoryStratosManagerServiceArtifactDistributionCoordinatorException"/>
+        </wsdl:operation>
+        <wsdl:operation name="canCartirdgeGroupBeRemoved">
+            <wsdl:input message="ns:canCartirdgeGroupBeRemovedRequest" wsaw:Action="urn:canCartirdgeGroupBeRemoved"/>
+            <wsdl:output message="ns:canCartirdgeGroupBeRemovedResponse" wsaw:Action="urn:canCartirdgeGroupBeRemovedResponse"/>
         </wsdl:operation>
         <wsdl:operation name="getApplicationSignUp">
             <wsdl:input message="ns:getApplicationSignUpRequest" wsaw:Action="urn:getApplicationSignUp"/>
@@ -258,6 +419,21 @@
                 <soap:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInApplications">
+            <soap:operation soapAction="urn:addUsedCartridgeGroupsInApplications" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="canCartridgeBeRemoved">
+            <soap:operation soapAction="urn:canCartridgeBeRemoved" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
         <wsdl:operation name="getApplicationSignUps">
             <soap:operation soapAction="urn:getApplicationSignUps" style="document"/>
             <wsdl:input>
@@ -279,6 +455,42 @@
                 <soap:fault use="literal" name="StratosManagerServiceArtifactDistributionCoordinatorException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInApplications">
+            <soap:operation soapAction="urn:removeUsedCartridgesInApplications" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInCartridgeSubGroups">
+            <soap:operation soapAction="urn:removeUsedCartridgeGroupsInCartridgeSubGroups" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInCartridgeGroups">
+            <soap:operation soapAction="urn:addUsedCartridgesInCartridgeGroups" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInApplications">
+            <soap:operation soapAction="urn:removeUsedCartridgeGroupsInApplications" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInCartridgeSubGroups">
+            <soap:operation soapAction="urn:addUsedCartridgeGroupsInCartridgeSubGroups" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInCartridgeGroups">
+            <soap:operation soapAction="urn:removeUsedCartridgesInCartridgeGroups" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="addDomainMapping">
             <soap:operation soapAction="urn:addDomainMapping" style="document"/>
             <wsdl:input>
@@ -288,6 +500,12 @@
                 <soap:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInApplications">
+            <soap:operation soapAction="urn:addUsedCartridgesInApplications" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="removeApplicationSignUp">
             <soap:operation soapAction="urn:removeApplicationSignUp" style="document"/>
             <wsdl:input>
@@ -295,15 +513,6 @@
             </wsdl:input>
             <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
                 <soap:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="removeDomainMapping">
-            <soap:operation soapAction="urn:removeDomainMapping" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
-            <wsdl:fault name="StratosManagerServiceDomainMappingException">
-                <soap:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="notifyArtifactUpdatedEventForRepository">
@@ -315,6 +524,33 @@
                 <soap:fault use="literal" name="StratosManagerServiceArtifactDistributionCoordinatorException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="removeDomainMapping">
+            <soap:operation soapAction="urn:removeDomainMapping" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:fault name="StratosManagerServiceDomainMappingException">
+                <soap:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="canCartirdgeGroupBeRemoved">
+            <soap:operation soapAction="urn:canCartirdgeGroupBeRemoved" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="addApplicationSignUp">
+            <soap:operation soapAction="urn:addApplicationSignUp" style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
+                <soap:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
+            </wsdl:fault>
+        </wsdl:operation>
         <wsdl:operation name="getApplicationSignUp">
             <soap:operation soapAction="urn:getApplicationSignUp" style="document"/>
             <wsdl:input>
@@ -323,15 +559,6 @@
             <wsdl:output>
                 <soap:body use="literal"/>
             </wsdl:output>
-            <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
-                <soap:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
-            </wsdl:fault>
-        </wsdl:operation>
-        <wsdl:operation name="addApplicationSignUp">
-            <soap:operation soapAction="urn:addApplicationSignUp" style="document"/>
-            <wsdl:input>
-                <soap:body use="literal"/>
-            </wsdl:input>
             <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
                 <soap:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
             </wsdl:fault>
@@ -350,6 +577,21 @@
             <wsdl:fault name="StratosManagerServiceDomainMappingException">
                 <soap12:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
             </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInApplications">
+            <soap12:operation soapAction="urn:addUsedCartridgeGroupsInApplications" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="canCartridgeBeRemoved">
+            <soap12:operation soapAction="urn:canCartridgeBeRemoved" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="getApplicationSignUps">
             <soap12:operation soapAction="urn:getApplicationSignUps" style="document"/>
@@ -372,6 +614,42 @@
                 <soap12:fault use="literal" name="StratosManagerServiceArtifactDistributionCoordinatorException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInApplications">
+            <soap12:operation soapAction="urn:removeUsedCartridgesInApplications" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInCartridgeSubGroups">
+            <soap12:operation soapAction="urn:removeUsedCartridgeGroupsInCartridgeSubGroups" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInCartridgeGroups">
+            <soap12:operation soapAction="urn:addUsedCartridgesInCartridgeGroups" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInApplications">
+            <soap12:operation soapAction="urn:removeUsedCartridgeGroupsInApplications" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInCartridgeSubGroups">
+            <soap12:operation soapAction="urn:addUsedCartridgeGroupsInCartridgeSubGroups" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInCartridgeGroups">
+            <soap12:operation soapAction="urn:removeUsedCartridgesInCartridgeGroups" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="addDomainMapping">
             <soap12:operation soapAction="urn:addDomainMapping" style="document"/>
             <wsdl:input>
@@ -381,6 +659,12 @@
                 <soap12:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
             </wsdl:fault>
         </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInApplications">
+            <soap12:operation soapAction="urn:addUsedCartridgesInApplications" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="removeApplicationSignUp">
             <soap12:operation soapAction="urn:removeApplicationSignUp" style="document"/>
             <wsdl:input>
@@ -388,6 +672,15 @@
             </wsdl:input>
             <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
                 <soap12:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
+            </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="notifyArtifactUpdatedEventForRepository">
+            <soap12:operation soapAction="urn:notifyArtifactUpdatedEventForRepository" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:fault name="StratosManagerServiceArtifactDistributionCoordinatorException">
+                <soap12:fault use="literal" name="StratosManagerServiceArtifactDistributionCoordinatorException"/>
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="removeDomainMapping">
@@ -399,13 +692,22 @@
                 <soap12:fault use="literal" name="StratosManagerServiceDomainMappingException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="notifyArtifactUpdatedEventForRepository">
-            <soap12:operation soapAction="urn:notifyArtifactUpdatedEventForRepository" style="document"/>
+        <wsdl:operation name="canCartirdgeGroupBeRemoved">
+            <soap12:operation soapAction="urn:canCartirdgeGroupBeRemoved" style="document"/>
             <wsdl:input>
                 <soap12:body use="literal"/>
             </wsdl:input>
-            <wsdl:fault name="StratosManagerServiceArtifactDistributionCoordinatorException">
-                <soap12:fault use="literal" name="StratosManagerServiceArtifactDistributionCoordinatorException"/>
+            <wsdl:output>
+                <soap12:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="addApplicationSignUp">
+            <soap12:operation soapAction="urn:addApplicationSignUp" style="document"/>
+            <wsdl:input>
+                <soap12:body use="literal"/>
+            </wsdl:input>
+            <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
+                <soap12:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
             </wsdl:fault>
         </wsdl:operation>
         <wsdl:operation name="getApplicationSignUp">
@@ -420,20 +722,26 @@
                 <soap12:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
             </wsdl:fault>
         </wsdl:operation>
-        <wsdl:operation name="addApplicationSignUp">
-            <soap12:operation soapAction="urn:addApplicationSignUp" style="document"/>
-            <wsdl:input>
-                <soap12:body use="literal"/>
-            </wsdl:input>
-            <wsdl:fault name="StratosManagerServiceApplicationSignUpException">
-                <soap12:fault use="literal" name="StratosManagerServiceApplicationSignUpException"/>
-            </wsdl:fault>
-        </wsdl:operation>
     </wsdl:binding>
     <wsdl:binding name="StratosManagerServiceHttpBinding" type="ns:StratosManagerServicePortType">
         <http:binding verb="POST"/>
         <wsdl:operation name="getDomainMappings">
             <http:operation location="getDomainMappings"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInApplications">
+            <http:operation location="addUsedCartridgeGroupsInApplications"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="canCartridgeBeRemoved">
+            <http:operation location="canCartridgeBeRemoved"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -456,8 +764,50 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInApplications">
+            <http:operation location="removeUsedCartridgesInApplications"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInCartridgeSubGroups">
+            <http:operation location="removeUsedCartridgeGroupsInCartridgeSubGroups"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInCartridgeGroups">
+            <http:operation location="addUsedCartridgesInCartridgeGroups"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgeGroupsInApplications">
+            <http:operation location="removeUsedCartridgeGroupsInApplications"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgeGroupsInCartridgeSubGroups">
+            <http:operation location="addUsedCartridgeGroupsInCartridgeSubGroups"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="removeUsedCartridgesInCartridgeGroups">
+            <http:operation location="removeUsedCartridgesInCartridgeGroups"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
         <wsdl:operation name="addDomainMapping">
             <http:operation location="addDomainMapping"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="addUsedCartridgesInApplications">
+            <http:operation location="addUsedCartridgesInApplications"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -468,20 +818,20 @@
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="removeDomainMapping">
-            <http:operation location="removeDomainMapping"/>
-            <wsdl:input>
-                <mime:content type="text/xml" part="parameters"/>
-            </wsdl:input>
-        </wsdl:operation>
         <wsdl:operation name="notifyArtifactUpdatedEventForRepository">
             <http:operation location="notifyArtifactUpdatedEventForRepository"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
         </wsdl:operation>
-        <wsdl:operation name="getApplicationSignUp">
-            <http:operation location="getApplicationSignUp"/>
+        <wsdl:operation name="removeDomainMapping">
+            <http:operation location="removeDomainMapping"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="canCartirdgeGroupBeRemoved">
+            <http:operation location="canCartirdgeGroupBeRemoved"/>
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
@@ -494,6 +844,15 @@
             <wsdl:input>
                 <mime:content type="text/xml" part="parameters"/>
             </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="getApplicationSignUp">
+            <http:operation location="getApplicationSignUp"/>
+            <wsdl:input>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:input>
+            <wsdl:output>
+                <mime:content type="text/xml" part="parameters"/>
+            </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:service name="StratosManagerService">


### PR DESCRIPTION
The purpose of the pull request is to incorporate validation when either a cartridge or cartridge group is removed - essentially these can only be remove if they are not included in either cartridge groups or applications.
This fixes STRATOS-1092

Performed the following testing on this PR.
1. add cartridge - remove cartridge = OK
2. add cartridge - add application with cartridge - remove cartridge = OK
3. add cartridge - add service group - remove cartridge = OK
4. add cartridge - add service group - add application with service group and cartridge - remove service group - remove cartirdge = OK
