### PR TITLE
Cartridge Agent - Fixed missing env_params variable in member activated event on defaultextensionhandler

### DIFF
--- a/components/org.apache.stratos.python.cartridge.agent/cartridgeagent/cartridgeagent/modules/extensions/defaultextensionhandler.py
+++ b/components/org.apache.stratos.python.cartridge.agent/cartridgeagent/cartridgeagent/modules/extensions/defaultextensionhandler.py
@@ -129,7 +129,9 @@ class DefaultExtensionHandler(AbstractExtensionHandler):
 
     def on_member_activated_event(self, member_activated_event):
         self.log.info("Member activated event received: [service] %r [cluster] %r [member] %r"
-            % (member_activated_event.service_name, member_activated_event.cluster_id, member_activated_event.member_id))
+                      % (member_activated_event.service_name,
+                         member_activated_event.cluster_id,
+                         member_activated_event.member_id))
 
         topology_consistent = extensionutils.check_topology_consistency(
             member_activated_event.service_name,
@@ -140,7 +142,8 @@ class DefaultExtensionHandler(AbstractExtensionHandler):
             self.log.error("Topology is inconsistent...failed to execute member activated event")
             return
 
-        extensionutils.execute_member_activated_extension(env_params)
+
+        extensionutils.execute_member_activated_extension({})
 
     def on_complete_topology_event(self, complete_topology_event):
         self.log.debug("Complete topology event received")


### PR DESCRIPTION
Fixes the following error on Cartridge Agent when executing MemberActivatedEvent extension, by passing an empty dictionary as the environment parameters

[2015-01-29 08:16:23,395] ERROR {agent.py:on_member_activated} - Error processing member activated event
Traceback (most recent call last):
  File "agent.py", line 228, in on_member_activated
    CartridgeAgent.extension_handler.on_member_activated_event(event_obj)
  File "/mnt/apache-stratos-python-cartridge-agent-4.1.0-SNAPSHOT/modules/extensions/defaultextensionhandler.py", line 143, in on_member_activated_event
    extensionutils.execute_member_activated_extension(env_params)
NameError: global name 'env_params' is not defined