### PR TITLE
Fixing minor typo in the Single Cartridge OpenStack sample application deployment

### DIFF
--- a/samples/applications/single-cartridge/iaases/openstack/artifacts/dep_single_group.json
+++ b/samples/applications/single-cartridge/iaases/openstack/artifacts/dep_single_group.json
@@ -25,7 +25,7 @@
             "alias": "php1",
             "networkPartition": [
                 {
-                    "id": "OS-P1",
+                    "id": "openstack_R1",
                     "partitionAlgo": "one-after-another",
                     "partitions": [
                         {


### PR DESCRIPTION
This fixes the NPE thrown when running the Single Cartridge OpenStack sample. 