### PR TITLE
Change the fault members identifying way

### DIFF
--- a/components/org.apache.stratos.load.balancer/src/main/java/org/apache/stratos/load/balancer/endpoint/TenantAwareLoadBalanceEndpoint.java
+++ b/components/org.apache.stratos.load.balancer/src/main/java/org/apache/stratos/load/balancer/endpoint/TenantAwareLoadBalanceEndpoint.java
@@ -801,10 +801,10 @@ public class TenantAwareLoadBalanceEndpoint extends org.apache.synapse.endpoints
         private org.apache.axis2.clustering.Member currentMember;
         private Endpoint currentEp;
         private EndpointReference to;
-        private Map<String, Boolean> faultyMembers;
+        private Map<String, Boolean> faultyMemberIds;
 
         public TenantAwareLoadBalanceFaultHandler() {
-            faultyMembers = new HashMap<String, Boolean>();
+            faultyMemberIds = new HashMap<String, Boolean>();
         }
 
         @Override
@@ -848,7 +848,7 @@ public class TenantAwareLoadBalanceEndpoint extends org.apache.synapse.endpoints
                 }
 
                 // Add current member to faulty members
-                faultyMembers.put(currentMember.getHostName(), true);
+                faultyMemberIds.put(currentMember.getProperties().getProperty(LoadBalancerConstants.MEMBER_ID), true);
 
                 currentMember = findNextMember(synCtx);
                 if (currentMember == null) {
@@ -858,7 +858,7 @@ public class TenantAwareLoadBalanceEndpoint extends org.apache.synapse.endpoints
                     }
                     throwSynapseException(synCtx, 404, msg);
                 }
-                if (faultyMembers.containsKey(currentMember.getHostName())) {
+                if (faultyMemberIds.containsKey(currentMember.getProperties().getProperty(LoadBalancerConstants.MEMBER_ID))) {
                     // This member has been identified as faulty previously. It implies that
                     // this request could not be served by any of the members in the cluster.
                     throwSynapseException(synCtx, 404, String.format("Requested resource could not be found"));


### PR DESCRIPTION
When same host having more than one instance and if one instance goes
down fault member map contain the host name. It is a bug. It must be
unique for each instance. Change identifier to mamber_id witch unique
one in conf file