### PR TITLE
PCA - Check ports activity when publishing instance activated event. 

### DIFF
--- a/components/org.apache.stratos.cartridge.agent/src/main/java/org/apache/stratos/cartridge/agent/event/publisher/CartridgeAgentEventPublisher.java
+++ b/components/org.apache.stratos.cartridge.agent/src/main/java/org/apache/stratos/cartridge/agent/event/publisher/CartridgeAgentEventPublisher.java
@@ -149,8 +149,8 @@ public class CartridgeAgentEventPublisher {
 					for (Integer port: ports){
 						portsStr += port + ", ";
 					}
-					log.info(String.format(
-							"Ports activation timed out. Aborting InstanceActivatedEvent publishing. [IPAdress] %s [Ports] %s",
+					log.error(String.format(
+							"Ports activation timed out. Aborting InstanceActivatedEvent publishing. [IPAddress] %s [Ports] %s",
 							listenAddress,
 							portsStr));
 				}

--- a/components/org.apache.stratos.python.cartridge.agent/src/main/python/cartridge.agent/cartridge.agent/agent.py
+++ b/components/org.apache.stratos.python.cartridge.agent/src/main/python/cartridge.agent/cartridge.agent/agent.py
@@ -88,13 +88,6 @@ class CartridgeAgent(threading.Thread):
         except Exception as e:
             self.__log.exception("Error processing start servers event: %s" % e)
 
-        # Wait for all ports to be active
-        cartridgeagentutils.wait_until_ports_active(
-            self.__config.listen_address,
-            self.__config.ports,
-            int(self.__config.read_property("port.check.timeout", critical=False))
-        )
-
         # check if artifact management is required before publishing instance activated event
         repo_url = self.__config.repo_url
         if repo_url is None or str(repo_url).strip() == "":

--- a/components/org.apache.stratos.python.cartridge.agent/src/main/python/cartridge.agent/cartridge.agent/modules/util/cartridgeagentutils.py
+++ b/components/org.apache.stratos.python.cartridge.agent/src/main/python/cartridge.agent/cartridge.agent/modules/util/cartridgeagentutils.py
@@ -84,10 +84,12 @@ def wait_until_ports_active(ip_address, ports, ports_check_timeout=600000):
 
         if duration > ports_check_timeout:
             log.info("Port check timeout reached: [ip] %r [ports] %r [timeout] %r" % (ip_address, ports, ports_check_timeout))
-            return
+            return False
 
         time.sleep(5)
+
     log.info("Ports activated: [ip] %r [ports] %r" % (ip_address, ports))
+    return True
 
 
 def check_ports_active(ip_address, ports):


### PR DESCRIPTION
In this fix I've moved the ports activation check to InstanceActivatedEvent publishing. Whenever InstanceActivatedEvent is to be published, it will check if the ports are active, and if not the event will not be published. The rationale is if a service is not active there is no point in marking the instance as active. 

Verified for unbroken functionality using the integration test. 