### PR TITLE
Added exception for persisting autoscaler policy in registry manager

### DIFF
--- a/components/org.apache.stratos.autoscaler/src/main/java/org/apache/stratos/autoscaler/pojo/policy/PolicyManager.java
+++ b/components/org.apache.stratos.autoscaler/src/main/java/org/apache/stratos/autoscaler/pojo/policy/PolicyManager.java
@@ -71,11 +71,11 @@ public class PolicyManager {
         if (log.isInfoEnabled()) {
             log.info(String.format("Adding autoscaling policy: [id] %s", policy.getId()));
         }
-        if(StringUtils.isEmpty(policy.getId())){
+        if (StringUtils.isEmpty(policy.getId())) {
             throw new AutoScalerException("Autoscaling policy id cannot be empty");
         }
-        this.addASPolicyToInformationModel(policy);
         RegistryManager.getInstance().persistAutoscalerPolicy(policy);
+        this.addASPolicyToInformationModel(policy);
         if (log.isInfoEnabled()) {
             log.info(String.format("Autoscaling policy is added successfully: [id] %s", policy.getId()));
         }

--- a/components/org.apache.stratos.autoscaler/src/main/java/org/apache/stratos/autoscaler/registry/RegistryManager.java
+++ b/components/org.apache.stratos.autoscaler/src/main/java/org/apache/stratos/autoscaler/registry/RegistryManager.java
@@ -117,11 +117,17 @@ public class RegistryManager {
     }
 
     public void persistAutoscalerPolicy(AutoscalePolicy autoscalePolicy) {
-        String resourcePath = AutoscalerConstants.AUTOSCALER_RESOURCE + AutoscalerConstants.AS_POLICY_RESOURCE + "/" + autoscalePolicy.getId();
-        persist(autoscalePolicy, resourcePath);
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Autoscaler policy written to registry: [id] %s [name] %s [description] %s",
-                    autoscalePolicy.getId(), autoscalePolicy.getDisplayName(), autoscalePolicy.getDescription()));
+        try {
+            String resourcePath = AutoscalerConstants.AUTOSCALER_RESOURCE +
+                    AutoscalerConstants.AS_POLICY_RESOURCE + "/" + autoscalePolicy.getId();
+            persist(autoscalePolicy, resourcePath);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Autoscaler policy written to registry: [id] %s [name] %s [description] %s",
+                        autoscalePolicy.getId(), autoscalePolicy.getDisplayName(), autoscalePolicy.getDescription()));
+            }
+        } catch (Exception e) {
+            throw new AutoScalerException((String.format("Unable to persist autoscaler policy [autoscaler-policy-id] %s"
+                    , autoscalePolicy.getId())), e);
         }
     }
 


### PR DESCRIPTION
Added registry exception for persisting autoscaler policy in registry manager
Also ensured the autoscaler policy is not added to the information model in policy manager, if the adding of the autoscaler policy is unsuccessful