### PR TITLE
Cartridge group validation

### DIFF
--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
@@ -441,7 +441,7 @@ public class StratosApiV41 extends AbstractApi {
     @AuthorizationAction("/permission/protected/manage/addServiceGroup")
     @SuperTenantService(true)
     public Response addServiceGroup(
-            GroupBean serviceGroupDefinition) throws RestAPIException, InvalidCartridgeGroupDefinitionException {
+            GroupBean serviceGroupDefinition) throws RestAPIException {
         try {
             StratosApiV41Utils.addServiceGroup(serviceGroupDefinition);
             URI url = uriInfo.getAbsolutePathBuilder().path(serviceGroupDefinition.getName()).build();

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
@@ -453,6 +453,15 @@ public class StratosApiV41 extends AbstractApi {
             if (e.getCause().getMessage().contains("already exists")) {
                 return Response.status(Response.Status.CONFLICT).entity(new StatusResponseBean(
                         Response.Status.CONFLICT.getStatusCode(), "Cartridge group not found")).build();
+            } else if(e.getCause().getMessage().contains("duplicate cartridges")) {
+                return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
+                        Response.Status.BAD_REQUEST.getStatusCode(), "Cartridges duplicated in the group definition")).build();
+            } else if(e.getCause().getMessage().contains("duplicate groups")) {
+                return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
+                        Response.Status.BAD_REQUEST.getStatusCode(), "Groups duplicated in the group definition")).build();
+            } else if(e.getCause().getMessage().contains("cyclic group")) {
+                return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
+                        Response.Status.BAD_REQUEST.getStatusCode(), "Cyclic group behaviour identified in the group definition")).build();
             } else {
                 throw e;
             }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
@@ -441,7 +441,7 @@ public class StratosApiV41 extends AbstractApi {
     @AuthorizationAction("/permission/protected/manage/addServiceGroup")
     @SuperTenantService(true)
     public Response addServiceGroup(
-            GroupBean serviceGroupDefinition) throws RestAPIException {
+            GroupBean serviceGroupDefinition) throws RestAPIException, InvalidCartridgeGroupDefinitionException {
         try {
             StratosApiV41Utils.addServiceGroup(serviceGroupDefinition);
             URI url = uriInfo.getAbsolutePathBuilder().path(serviceGroupDefinition.getName()).build();
@@ -449,22 +449,13 @@ public class StratosApiV41 extends AbstractApi {
             return Response.created(url).entity(new StatusResponseBean(Response.Status.CREATED.getStatusCode(),
                     String.format("Cartridge Group added successfully: [cartridge-group] %s",
                             serviceGroupDefinition.getName()))).build();
+        } catch (InvalidCartridgeGroupDefinitionException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
+                    Response.Status.BAD_REQUEST.getStatusCode(), e.getMessage())).build();
         } catch (RestAPIException e) {
             if (e.getCause().getMessage().contains("already exists")) {
                 return Response.status(Response.Status.CONFLICT).entity(new StatusResponseBean(
                         Response.Status.CONFLICT.getStatusCode(), "Cartridge group not found")).build();
-            } else if (e.getCause().getMessage().contains("duplicate cartridges")) {
-                return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
-                        Response.Status.BAD_REQUEST.getStatusCode(), "Cartridges duplicated in the group " +
-                        "definition")).build();
-            } else if (e.getCause().getMessage().contains("duplicate groups")) {
-                return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
-                        Response.Status.BAD_REQUEST.getStatusCode(), "Groups duplicated in the group " +
-                        "definition")).build();
-            } else if (e.getCause().getMessage().contains("cyclic group")) {
-                return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
-                        Response.Status.BAD_REQUEST.getStatusCode(), "Cyclic group behaviour identified in the group " +
-                        "definition")).build();
             } else {
                 throw e;
             }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
@@ -453,15 +453,18 @@ public class StratosApiV41 extends AbstractApi {
             if (e.getCause().getMessage().contains("already exists")) {
                 return Response.status(Response.Status.CONFLICT).entity(new StatusResponseBean(
                         Response.Status.CONFLICT.getStatusCode(), "Cartridge group not found")).build();
-            } else if(e.getCause().getMessage().contains("duplicate cartridges")) {
+            } else if (e.getCause().getMessage().contains("duplicate cartridges")) {
                 return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
-                        Response.Status.BAD_REQUEST.getStatusCode(), "Cartridges duplicated in the group definition")).build();
-            } else if(e.getCause().getMessage().contains("duplicate groups")) {
+                        Response.Status.BAD_REQUEST.getStatusCode(), "Cartridges duplicated in the group " +
+                        "definition")).build();
+            } else if (e.getCause().getMessage().contains("duplicate groups")) {
                 return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
-                        Response.Status.BAD_REQUEST.getStatusCode(), "Groups duplicated in the group definition")).build();
-            } else if(e.getCause().getMessage().contains("cyclic group")) {
+                        Response.Status.BAD_REQUEST.getStatusCode(), "Groups duplicated in the group " +
+                        "definition")).build();
+            } else if (e.getCause().getMessage().contains("cyclic group")) {
                 return Response.status(Response.Status.BAD_REQUEST).entity(new StatusResponseBean(
-                        Response.Status.BAD_REQUEST.getStatusCode(), "Cyclic group behaviour identified in the group definition")).build();
+                        Response.Status.BAD_REQUEST.getStatusCode(), "Cyclic group behaviour identified in the group " +
+                        "definition")).build();
             } else {
                 throw e;
             }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -980,49 +980,40 @@ public class StratosApiV41Utils {
             List<String> groupNames;
             String[] cartridgeGroupNames;
 
-            // if any cartridges are specified in the group, they should be already deployed
-            if (serviceGroupDefinition.getCartridges() != null) {
-
                 if (log.isDebugEnabled()) {
                     log.debug("checking cartridges in cartridge group " + serviceGroupDefinition.getName());
                 }
 
                 findCartridgesInGroupBean(serviceGroupDefinition, cartridgeTypes);
 
-                Set<String> duplicates = findDuplicates(cartridgeTypes);
-                if (duplicates.size() > 0) {
-                    StringBuilder duplicatesOutput = new StringBuilder();
-                    for (String dup : duplicates) {
-                        duplicatesOutput.append(dup).append(" ");
-                    }
-                    if (log.isDebugEnabled()) {
-                        log.debug("duplicate cartridges defined: " + duplicatesOutput.toString());
-                    }
-                    throw new RestAPIException("Invalid Service Group definition, duplicate cartridges defined:" +
-                            duplicatesOutput.toString());
-                }
+            //validate the group definition to check if cartridges duplicate in any groups defined
+            validateCartridgeDuplicationInGroupDefinition(serviceGroupDefinition);
+
+            //validate the group definition to check if groups duplicate in any groups and
+            //validate the group definition to check for cyclic group behaviour
+            validateGroupDuplicationInGroupDefinition(serviceGroupDefinition, new ArrayList<String>());
 
                 CloudControllerServiceClient ccServiceClient = getCloudControllerServiceClient();
 
-                cartridgeNames = new String[cartridgeTypes.size()];
-                int i = 0;
-                for (String cartridgeType : cartridgeTypes) {
-                    try {
-                        if (ccServiceClient.getCartridge(cartridgeType) == null) {
-                            // cartridge is not deployed, can't continue
-                            log.error("Invalid cartridge found in cartridge group " + cartridgeType);
-                            throw new RestAPIException("No Cartridge Definition found with type " + cartridgeType);
-                        } else {
-                            cartridgeNames[i] = cartridgeType;
-                            i++;
-                        }
-                    } catch (RemoteException e) {
-                        throw new RestAPIException(e);
-                    } catch (CloudControllerServiceCartridgeNotFoundExceptionException e) {
-                        throw new RestAPIException(e);
+            cartridgeNames = new String[cartridgeTypes.size()];
+            int j = 0;
+            for (String cartridgeType : cartridgeTypes) {
+                try {
+                    if (ccServiceClient.getCartridge(cartridgeType) == null) {
+                        // cartridge is not deployed, can't continue
+                        log.error("Invalid cartridge found in cartridge group " + cartridgeType);
+                        throw new RestAPIException("No Cartridge Definition found with type " + cartridgeType);
+                    } else {
+                        cartridgeNames[j] = cartridgeType;
+                        j++;
                     }
+                } catch (RemoteException e) {
+                    throw new RestAPIException(e);
+                } catch (CloudControllerServiceCartridgeNotFoundExceptionException e) {
+                    throw new RestAPIException(e);
                 }
             }
+
 
             // if any sub groups are specified in the group, they should be already deployed
             if (serviceGroupDefinition.getGroups() != null) {
@@ -1188,12 +1179,12 @@ public class StratosApiV41Utils {
 
             // Remove the dependent cartridges and cartridge groups from Stratos Manager cache
             // - done after service group has been removed
-            if (serviceGroup.getCartridges() != null) {
-                List<String> cartridgeList = new ArrayList<String>();
-                findCartridgesInServiceGroup(serviceGroup, cartridgeList);
-                String[] cartridgeNames = cartridgeList.toArray(new String[cartridgeList.size()]);
-                smServiceClient.removeUsedCartridgesInCartridgeGroups(name, cartridgeNames);
-            }
+
+            List<String> cartridgeList = new ArrayList<String>();
+            findCartridgesInServiceGroup(serviceGroup, cartridgeList);
+            String[] cartridgeNames = cartridgeList.toArray(new String[cartridgeList.size()]);
+            smServiceClient.removeUsedCartridgesInCartridgeGroups(name, cartridgeNames);
+
         } catch (RemoteException e) {
             throw new RestAPIException("Could not remove cartridge groups", e);
         }
@@ -1213,9 +1204,11 @@ public class StratosApiV41Utils {
             return;
         }
 
-        for (String cartridge : serviceGroup.getCartridges()) {
-            if (!cartridges.contains(cartridge)) {
-                cartridges.add(cartridge);
+        if (serviceGroup.getCartridges() != null) {
+            for (String cartridge : serviceGroup.getCartridges()) {
+                if (!cartridges.contains(cartridge)) {
+                    cartridges.add(cartridge);
+                }
             }
         }
 
@@ -1238,9 +1231,11 @@ public class StratosApiV41Utils {
             return;
         }
 
-        for (String cartridge : groupBean.getCartridges()) {
-            if (!cartridges.contains(cartridge)) {
-                cartridges.add(cartridge);
+        if (groupBean.getCartridges() != null) {
+            for (String cartridge : groupBean.getCartridges()) {
+                if (!cartridges.contains(cartridge)) {
+                    cartridges.add(cartridge);
+                }
             }
         }
 
@@ -3198,6 +3193,112 @@ public class StratosApiV41Utils {
             throw new RestAPIException(e.getMessage());
         }
         return userList;
+    }
+
+    /**
+     * This method is to validate the cartridge duplication in the group definition recursively for group within groups
+     *
+     * @param groupBean - cartridge group definition
+     * @throws RestAPIException - throws the rest api exception when the group definition is invalid
+     */
+    private static void validateCartridgeDuplicationInGroupDefinition(GroupBean groupBean) throws  RestAPIException{
+        if (groupBean == null) {
+            return;
+        }
+        List<String> cartridges = new ArrayList<String>();
+        if (groupBean.getCartridges() != null) {
+            if (groupBean.getCartridges().size() > 1) {
+                cartridges.addAll(groupBean.getCartridges());
+                validateCartridgeDuplicationInGroup(cartridges);
+            }
+        }
+        if (groupBean.getGroups() != null) {
+            //Recursive because to check groups inside groups
+            for (GroupBean group : groupBean.getGroups()) {
+                validateCartridgeDuplicationInGroupDefinition(group);
+            }
+        }
+    }
+    /**
+     * This method is to validate the duplication of cartridges from the given list
+     *
+     * @param cartridges - list of strings which holds the cartridgeTypes values
+     * @throws RestAPIException - throws the rest api exception when the cartridges are duplicated
+     */
+    private static void validateCartridgeDuplicationInGroup(List<String> cartridges) throws RestAPIException{
+        List<String> checkList = new ArrayList<String>();
+        for (String cartridge : cartridges) {
+            if (!checkList.contains(cartridge)) {
+                checkList.add(cartridge);
+            }
+            else {
+                if (log.isDebugEnabled()) {
+                    log.debug("duplicate cartridges defined: " + cartridge);
+                }
+                throw new RestAPIException("Invalid Service Group definition, duplicate cartridges defined: " +
+                        cartridge);
+            }
+        }
+    }
+    /**
+     * This method is to validate the group duplication in the group definition recursively for group within groups
+     *
+     * @param groupBean - cartridge group definition
+     * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
+     * @throws RestAPIException - throws the rest api exception when the group definition is invalid
+     */
+    private static void validateGroupDuplicationInGroupDefinition(GroupBean groupBean, List<String> parentGroups)
+            throws  RestAPIException{
+        if (groupBean == null) {
+            return;
+        }
+        List<String> groups = new ArrayList<String>();
+        parentGroups.add(groupBean.getName());
+        if (groupBean.getGroups() != null) {
+            if (!groupBean.getGroups().isEmpty()) {
+                for (GroupBean g : groupBean.getGroups()) {
+                    groups.add(g.getName());
+                }
+                validateGroupDuplicationInGroup(groups, parentGroups);
+            }
+        }
+        if (groupBean.getGroups() != null) {
+            //Recursive because to check groups inside groups
+            for (GroupBean group : groupBean.getGroups()) {
+                validateGroupDuplicationInGroupDefinition(group, parentGroups);
+                parentGroups.remove(group.getName());
+            }
+        }
+    }
+    /**
+     * This method is to validate the duplication of groups in the same level and to validate cyclic behaviour of groups
+     *
+     * @param groups - cartridge group definition
+     * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
+     * @throws RestAPIException - throws the rest api exception when group duplicate or when cyclic behaviour occurs
+     */
+    private static void validateGroupDuplicationInGroup(List<String> groups, List<String> parentGroups)
+            throws RestAPIException{
+        List<String> checkList = new ArrayList<String>();
+        for (String group : groups) {
+            if (!checkList.contains(group)) {
+                checkList.add(group);
+            }
+            else {
+                if (log.isDebugEnabled()) {
+                    log.debug("duplicate group defined: " + group);
+                }
+                throw new RestAPIException("Invalid Service Group definition, duplicate groups defined: " +
+                        group);
+            }
+            if (parentGroups.contains(group)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("cyclic group behaviour identified [group-name]: " + group);
+                }
+                throw new RestAPIException("Invalid Service Group definition, cyclic group behaviour identified: " +
+                        group);
+            }
+        }
     }
 
 }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -966,6 +966,7 @@ public class StratosApiV41Utils {
 
     /**
      * Add a Service Group
+     *
      * @param serviceGroupDefinition serviceGroupDefinition
      * @throws RestAPIException
      */
@@ -980,11 +981,11 @@ public class StratosApiV41Utils {
             List<String> groupNames;
             String[] cartridgeGroupNames;
 
-                if (log.isDebugEnabled()) {
-                    log.debug("checking cartridges in cartridge group " + serviceGroupDefinition.getName());
-                }
+            if (log.isDebugEnabled()) {
+                log.debug("checking cartridges in cartridge group " + serviceGroupDefinition.getName());
+            }
 
-                findCartridgesInGroupBean(serviceGroupDefinition, cartridgeTypes);
+            findCartridgesInGroupBean(serviceGroupDefinition, cartridgeTypes);
 
             //validate the group definition to check if cartridges duplicate in any groups defined
             validateCartridgeDuplicationInGroupDefinition(serviceGroupDefinition);
@@ -993,7 +994,7 @@ public class StratosApiV41Utils {
             //validate the group definition to check for cyclic group behaviour
             validateGroupDuplicationInGroupDefinition(serviceGroupDefinition, new ArrayList<String>());
 
-                CloudControllerServiceClient ccServiceClient = getCloudControllerServiceClient();
+            CloudControllerServiceClient ccServiceClient = getCloudControllerServiceClient();
 
             cartridgeNames = new String[cartridgeTypes.size()];
             int j = 0;
@@ -3201,7 +3202,7 @@ public class StratosApiV41Utils {
      * @param groupBean - cartridge group definition
      * @throws RestAPIException - throws the rest api exception when the group definition is invalid
      */
-    private static void validateCartridgeDuplicationInGroupDefinition(GroupBean groupBean) throws  RestAPIException{
+    private static void validateCartridgeDuplicationInGroupDefinition(GroupBean groupBean) throws RestAPIException {
         if (groupBean == null) {
             return;
         }
@@ -3219,19 +3220,19 @@ public class StratosApiV41Utils {
             }
         }
     }
+
     /**
      * This method is to validate the duplication of cartridges from the given list
      *
      * @param cartridges - list of strings which holds the cartridgeTypes values
      * @throws RestAPIException - throws the rest api exception when the cartridges are duplicated
      */
-    private static void validateCartridgeDuplicationInGroup(List<String> cartridges) throws RestAPIException{
+    private static void validateCartridgeDuplicationInGroup(List<String> cartridges) throws RestAPIException {
         List<String> checkList = new ArrayList<String>();
         for (String cartridge : cartridges) {
             if (!checkList.contains(cartridge)) {
                 checkList.add(cartridge);
-            }
-            else {
+            } else {
                 if (log.isDebugEnabled()) {
                     log.debug("duplicate cartridges defined: " + cartridge);
                 }
@@ -3240,15 +3241,16 @@ public class StratosApiV41Utils {
             }
         }
     }
+
     /**
      * This method is to validate the group duplication in the group definition recursively for group within groups
      *
-     * @param groupBean - cartridge group definition
+     * @param groupBean    - cartridge group definition
      * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
      * @throws RestAPIException - throws the rest api exception when the group definition is invalid
      */
     private static void validateGroupDuplicationInGroupDefinition(GroupBean groupBean, List<String> parentGroups)
-            throws  RestAPIException{
+            throws RestAPIException {
         if (groupBean == null) {
             return;
         }
@@ -3270,21 +3272,21 @@ public class StratosApiV41Utils {
             }
         }
     }
+
     /**
      * This method is to validate the duplication of groups in the same level and to validate cyclic behaviour of groups
      *
-     * @param groups - cartridge group definition
+     * @param groups       - cartridge group definition
      * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
      * @throws RestAPIException - throws the rest api exception when group duplicate or when cyclic behaviour occurs
      */
     private static void validateGroupDuplicationInGroup(List<String> groups, List<String> parentGroups)
-            throws RestAPIException{
+            throws RestAPIException {
         List<String> checkList = new ArrayList<String>();
         for (String group : groups) {
             if (!checkList.contains(group)) {
                 checkList.add(group);
-            }
-            else {
+            } else {
                 if (log.isDebugEnabled()) {
                     log.debug("duplicate group defined: " + group);
                 }
@@ -3300,5 +3302,4 @@ public class StratosApiV41Utils {
             }
         }
     }
-
 }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -968,6 +968,7 @@ public class StratosApiV41Utils {
      * Add a Service Group
      *
      * @param serviceGroupDefinition serviceGroupDefinition
+     * @throws InvalidCartridgeGroupDefinitionException
      * @throws RestAPIException
      */
     public static void addServiceGroup(GroupBean serviceGroupDefinition)
@@ -3205,7 +3206,7 @@ public class StratosApiV41Utils {
      * This method is to validate the cartridge duplication in the group definition recursively for group within groups
      *
      * @param groupBean - cartridge group definition
-     * @throws RestAPIException - throws the rest api exception when the group definition is invalid
+     * @throws InvalidCartridgeGroupDefinitionException - throws when the group definition is invalid
      */
     private static void validateCartridgeDuplicationInGroupDefinition(GroupBean groupBean)
             throws InvalidCartridgeGroupDefinitionException {
@@ -3231,7 +3232,7 @@ public class StratosApiV41Utils {
      * This method is to validate the duplication of cartridges from the given list
      *
      * @param cartridges - list of strings which holds the cartridgeTypes values
-     * @throws RestAPIException - throws the rest api exception when the cartridges are duplicated
+     * @throws InvalidCartridgeGroupDefinitionException - throws when the cartridges are duplicated
      */
     private static void validateCartridgeDuplicationInGroup(List<String> cartridges)
             throws InvalidCartridgeGroupDefinitionException {
@@ -3254,7 +3255,7 @@ public class StratosApiV41Utils {
      *
      * @param groupBean    - cartridge group definition
      * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
-     * @throws RestAPIException - throws the rest api exception when the group definition is invalid
+     * @throws InvalidCartridgeGroupDefinitionException - throws when the group definition is invalid
      */
     private static void validateGroupDuplicationInGroupDefinition(GroupBean groupBean, List<String> parentGroups)
             throws InvalidCartridgeGroupDefinitionException {
@@ -3285,7 +3286,7 @@ public class StratosApiV41Utils {
      *
      * @param groups       - cartridge group definition
      * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
-     * @throws RestAPIException - throws the rest api exception when group duplicate or when cyclic behaviour occurs
+     * @throws InvalidCartridgeGroupDefinitionException - throws when group duplicate or when cyclic behaviour occurs
      */
     private static void validateGroupDuplicationInGroup(List<String> groups, List<String> parentGroups)
             throws InvalidCartridgeGroupDefinitionException {

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -994,7 +994,7 @@ public class StratosApiV41Utils {
 
             //validate the group definition to check if groups duplicate in any groups and
             //validate the group definition to check for cyclic group behaviour
-            validateGroupDuplicationInGroupDefinition(serviceGroupDefinition, new ArrayList<String>());
+            validateGroupDuplicationInGroupDefinition(serviceGroupDefinition);
 
             CloudControllerServiceClient ccServiceClient = getCloudControllerServiceClient();
 
@@ -3250,13 +3250,25 @@ public class StratosApiV41Utils {
         }
     }
 
+
     /**
-     * This method is to validate the group duplication in the group definition recursively for group within groups
+     * This is a wrapper method to invoke validateGroupDuplicationInGroupDefinition with a new arraylist of string
      *
-     * @param groupBean    - cartridge group definition
-     * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
-     * @throws InvalidCartridgeGroupDefinitionException - throws when the group definition is invalid
+     * @param groupBean     - cartridge group definition
+     * @throws InvalidCartridgeGroupDefinitionException
      */
+    private static void validateGroupDuplicationInGroupDefinition(GroupBean groupBean)
+            throws InvalidCartridgeGroupDefinitionException {
+        validateGroupDuplicationInGroupDefinition(groupBean, new ArrayList<String>());
+    }
+
+        /**
+         * This is to validate the group duplication in the group definition recursively for group within groups
+         *
+         * @param groupBean    - cartridge group definition
+         * @param parentGroups - list of string which holds the parent group names (all parents in the hierarchy)
+         * @throws InvalidCartridgeGroupDefinitionException - throws when the group definition is invalid
+         */
     private static void validateGroupDuplicationInGroupDefinition(GroupBean groupBean, List<String> parentGroups)
             throws InvalidCartridgeGroupDefinitionException {
         if (groupBean == null) {

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -970,10 +970,11 @@ public class StratosApiV41Utils {
      * @param serviceGroupDefinition serviceGroupDefinition
      * @throws RestAPIException
      */
-    public static void addServiceGroup(GroupBean serviceGroupDefinition) throws RestAPIException {
+    public static void addServiceGroup(GroupBean serviceGroupDefinition)
+            throws InvalidCartridgeGroupDefinitionException, RestAPIException {
         try {
             if (serviceGroupDefinition == null) {
-                throw new RuntimeException("Service Group definition is null");
+                throw new RuntimeException("Cartridge group definition is null");
             }
 
             List<String> cartridgeTypes = new ArrayList<String>();
@@ -982,7 +983,7 @@ public class StratosApiV41Utils {
             String[] cartridgeGroupNames;
 
             if (log.isDebugEnabled()) {
-                log.debug("checking cartridges in cartridge group " + serviceGroupDefinition.getName());
+                log.debug("Checking cartridges in cartridge group " + serviceGroupDefinition.getName());
             }
 
             findCartridgesInGroupBean(serviceGroupDefinition, cartridgeTypes);
@@ -1009,7 +1010,9 @@ public class StratosApiV41Utils {
                         j++;
                     }
                 } catch (RemoteException e) {
-                    throw new RestAPIException(e);
+                    String message = "Could not add the cartridge group: " + serviceGroupDefinition.getName();
+                    log.error(message, e);
+                    throw new RestAPIException(message, e);
                 } catch (CloudControllerServiceCartridgeNotFoundExceptionException e) {
                     throw new RestAPIException(e);
                 }
@@ -1040,9 +1043,9 @@ public class StratosApiV41Utils {
                         duplicatesOutput.append(dup).append(" ");
                     }
                     if (log.isDebugEnabled()) {
-                        log.debug("duplicate subGroups defined: " + duplicatesOutput.toString());
+                        log.debug("duplicate sub-groups defined: " + duplicatesOutput.toString());
                     }
-                    throw new RestAPIException("Invalid Service Group definition, duplicate subGroups defined:" +
+                    throw new RestAPIException("Invalid cartridge group definition, duplicate sub-groups defined:" +
                             duplicatesOutput.toString());
                 }
             }
@@ -1056,6 +1059,8 @@ public class StratosApiV41Utils {
             // Add cartridge group elements to SM cache - done after service group has been added
             StratosManagerServiceClient smServiceClient = getStratosManagerServiceClient();
             smServiceClient.addUsedCartridgesInCartridgeGroups(serviceGroupDefinition.getName(), cartridgeNames);
+        } catch (InvalidCartridgeGroupDefinitionException e) {
+            throw e;
         } catch (Exception e) {
             // TODO: InvalidServiceGroupException is not received, only AxisFault. Need to fix get the custom exception
             String message = "Could not add cartridge group";
@@ -3202,7 +3207,8 @@ public class StratosApiV41Utils {
      * @param groupBean - cartridge group definition
      * @throws RestAPIException - throws the rest api exception when the group definition is invalid
      */
-    private static void validateCartridgeDuplicationInGroupDefinition(GroupBean groupBean) throws RestAPIException {
+    private static void validateCartridgeDuplicationInGroupDefinition(GroupBean groupBean)
+            throws InvalidCartridgeGroupDefinitionException {
         if (groupBean == null) {
             return;
         }
@@ -3227,7 +3233,8 @@ public class StratosApiV41Utils {
      * @param cartridges - list of strings which holds the cartridgeTypes values
      * @throws RestAPIException - throws the rest api exception when the cartridges are duplicated
      */
-    private static void validateCartridgeDuplicationInGroup(List<String> cartridges) throws RestAPIException {
+    private static void validateCartridgeDuplicationInGroup(List<String> cartridges)
+            throws InvalidCartridgeGroupDefinitionException {
         List<String> checkList = new ArrayList<String>();
         for (String cartridge : cartridges) {
             if (!checkList.contains(cartridge)) {
@@ -3236,8 +3243,8 @@ public class StratosApiV41Utils {
                 if (log.isDebugEnabled()) {
                     log.debug("duplicate cartridges defined: " + cartridge);
                 }
-                throw new RestAPIException("Invalid Service Group definition, duplicate cartridges defined: " +
-                        cartridge);
+                throw new InvalidCartridgeGroupDefinitionException("Invalid cartridge group definition, " +
+                        "duplicate cartridges defined: " + cartridge);
             }
         }
     }
@@ -3250,7 +3257,7 @@ public class StratosApiV41Utils {
      * @throws RestAPIException - throws the rest api exception when the group definition is invalid
      */
     private static void validateGroupDuplicationInGroupDefinition(GroupBean groupBean, List<String> parentGroups)
-            throws RestAPIException {
+            throws InvalidCartridgeGroupDefinitionException {
         if (groupBean == null) {
             return;
         }
@@ -3281,7 +3288,7 @@ public class StratosApiV41Utils {
      * @throws RestAPIException - throws the rest api exception when group duplicate or when cyclic behaviour occurs
      */
     private static void validateGroupDuplicationInGroup(List<String> groups, List<String> parentGroups)
-            throws RestAPIException {
+            throws InvalidCartridgeGroupDefinitionException {
         List<String> checkList = new ArrayList<String>();
         for (String group : groups) {
             if (!checkList.contains(group)) {
@@ -3290,15 +3297,15 @@ public class StratosApiV41Utils {
                 if (log.isDebugEnabled()) {
                     log.debug("duplicate group defined: " + group);
                 }
-                throw new RestAPIException("Invalid Service Group definition, duplicate groups defined: " +
-                        group);
+                throw new InvalidCartridgeGroupDefinitionException("Invalid cartridge group definition, " +
+                        "duplicate groups defined: " + group);
             }
             if (parentGroups.contains(group)) {
                 if (log.isDebugEnabled()) {
                     log.debug("cyclic group behaviour identified [group-name]: " + group);
                 }
-                throw new RestAPIException("Invalid Service Group definition, cyclic group behaviour identified: " +
-                        group);
+                throw new InvalidCartridgeGroupDefinitionException("Invalid cartridge group definition, " +
+                        "cyclic group behaviour identified: " + group);
             }
         }
     }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/exception/InvalidCartridgeGroupDefinitionException.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/exception/InvalidCartridgeGroupDefinitionException.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one 
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+ * KIND, either express or implied.  See the License for the 
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.stratos.rest.endpoint.exception;
+
+import javax.ws.rs.core.Response;
+
+public class InvalidCartridgeGroupDefinitionException extends Exception {
+
+    private static final long serialVersionUID = 7396616678984911736L;
+
+    private String message;
+    private Response.Status httpStatusCode;
+
+    public InvalidCartridgeGroupDefinitionException() {
+        super();
+    }
+
+    public InvalidCartridgeGroupDefinitionException(String message, Throwable cause) {
+        super(message, cause);
+        this.message = message;
+    }
+
+    public InvalidCartridgeGroupDefinitionException(Response.Status httpStatusCode, String message, Throwable cause) {
+        super(message, cause);
+        this.message = message;
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public InvalidCartridgeGroupDefinitionException(String message) {
+        super(message);
+        this.message = message;
+    }
+
+    public InvalidCartridgeGroupDefinitionException(Response.Status httpStatusCode, String message) {
+        super(message);
+        this.message = message;
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public InvalidCartridgeGroupDefinitionException(Throwable cause) {
+        super(cause);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Response.Status getHTTPStatusCode() {
+        return httpStatusCode;
+    }
+}


### PR DESCRIPTION
Added cartridge group validation for checking 
- duplicate cartridges in the same level
- duplicate groups in the same level
- cyclic behaviour of groups

Fixed a logical flaw in adding and removing service groups.