### PR TITLE
Changing the get available kubernetes logging

### DIFF
--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -1976,7 +1976,10 @@ public class StratosApiV41Utils {
                 org.apache.stratos.cloud.controller.stub.domain.kubernetes.KubernetesCluster[]
                         kubernetesClusters = cloudControllerServiceClient.getAvailableKubernetesClusters();
                 if (kubernetesClusters == null) {
-                    log.error("Could not find any Kubernetes Clusters.");
+                    if (log.isDebugEnabled()) {
+                        log.debug("There are no available Kubernetes clusters");
+                    }
+
                     return null;
                 }
 


### PR DESCRIPTION
GET /api/kubernetesClusters prints an error log "Could not find any Kubernetes Clusters". Therefore it has been changed to debug log to state "There are no Kubernetes cluster available".