### PR TITLE
Fixed deactivating non-exist tenant in cli

### DIFF
--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/RestCommandLineService.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/RestCommandLineService.java
@@ -34,6 +34,7 @@ import org.apache.stratos.cli.exception.ExceptionMapper;
 import org.apache.stratos.cli.utils.CliConstants;
 import org.apache.stratos.cli.utils.CliUtils;
 import org.apache.stratos.cli.utils.RowMapper;
+import org.apache.stratos.common.beans.ResponseMessageBean;
 import org.apache.stratos.common.beans.TenantInfoBean;
 import org.apache.stratos.common.beans.UserInfoBean;
 import org.apache.stratos.common.beans.application.ApplicationBean;
@@ -825,8 +826,8 @@ public class RestCommandLineService {
                 return;
             } else {
                 String resultString = CliUtils.getHttpResponseString(response);
-                ExceptionMapper exception = gson.fromJson(resultString, ExceptionMapper.class);
-                System.out.println(exception);
+                String errorMsg = gson.fromJson(resultString, ResponseMessageBean.class).getMessage();
+                System.out.println(errorMsg);
             }
 
         } catch (Exception e) {
@@ -858,8 +859,8 @@ public class RestCommandLineService {
                 System.out.println("You have successfully activated the tenant: " + tenantDomain);
             } else {
                 String resultString = CliUtils.getHttpResponseString(response);
-                ExceptionMapper exception = gson.fromJson(resultString, ExceptionMapper.class);
-                System.out.println(exception);
+                String errorMsg = gson.fromJson(resultString, ResponseMessageBean.class).getMessage();
+                System.out.println(errorMsg);
             }
 
         } catch (Exception e) {

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
@@ -819,11 +819,11 @@ public class StratosApiV41 extends AbstractApi {
         } catch (AutoscalerServiceInvalidApplicationPolicyExceptionException e) {
             return Response.status(Response.Status.BAD_REQUEST).entity(new ResponseMessageBean(
                     ResponseMessageBean.ERROR, "Invalid application policy")).build();
-        } catch(AutoscalerServiceApplicationPolicyAlreadyExistsExceptionException e){
+        } catch (AutoscalerServiceApplicationPolicyAlreadyExistsExceptionException e) {
             return Response.status(Response.Status.CONFLICT).entity(new ResponseMessageBean(
                     ResponseMessageBean.ERROR, "Application policy already exists")).build();
 
-        }catch (RestAPIException e) {
+        } catch (RestAPIException e) {
             throw e;
         }
 
@@ -1606,7 +1606,13 @@ public class StratosApiV41 extends AbstractApi {
     public Response activateTenant(
             @PathParam("tenantDomain") String tenantDomain) throws RestAPIException {
 
-        StratosApiV41Utils.activateTenant(tenantDomain);
+        try {
+            StratosApiV41Utils.activateTenant(tenantDomain);
+        } catch (InvalidDomainException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(new ResponseMessageBean(
+                    ResponseMessageBean.ERROR, "Invalid domain")).build();
+        }
+
         return Response.ok().entity(new ResponseMessageBean(ResponseMessageBean.SUCCESS,
                 String.format("Tenant activated successfully: [tenant] %s", tenantDomain))).build();
     }
@@ -1627,7 +1633,13 @@ public class StratosApiV41 extends AbstractApi {
     public Response deactivateTenant(
             @PathParam("tenantDomain") String tenantDomain) throws RestAPIException {
 
-        StratosApiV41Utils.deactivateTenant(tenantDomain);
+        try {
+            StratosApiV41Utils.deactivateTenant(tenantDomain);
+        } catch (InvalidDomainException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(new ResponseMessageBean(
+                    ResponseMessageBean.ERROR, "Invalid domain")).build();
+        }
+
         return Response.ok().entity(new ResponseMessageBean(ResponseMessageBean.SUCCESS,
                 String.format("Tenant deactivated successfully: [tenant] %s", tenantDomain))).build();
     }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -119,7 +119,7 @@ public class StratosApiV41Utils {
             }
 
             List<IaasProviderBean> iaasProviders = cartridgeBean.getIaasProvider();
-            if((iaasProviders == null) || iaasProviders.size() == 0) {
+            if ((iaasProviders == null) || iaasProviders.size() == 0) {
                 throw new RestAPIException(String.format("IaaS providers not found in cartridge: %s",
                         cartridgeBean.getType()));
             }
@@ -166,7 +166,7 @@ public class StratosApiV41Utils {
             }
 
             List<IaasProviderBean> iaasProviders = cartridgeBean.getIaasProvider();
-            if((iaasProviders == null) || iaasProviders.size() == 0) {
+            if ((iaasProviders == null) || iaasProviders.size() == 0) {
                 throw new RestAPIException(String.format("IaaS providers not found in cartridge: %s",
                         cartridgeBean.getType()));
             }
@@ -654,7 +654,7 @@ public class StratosApiV41Utils {
      * @throws RestAPIException
      */
     public static void addApplicationPolicy(ApplicationPolicyBean applicationPolicyBean) throws RestAPIException,
-            AutoscalerServiceInvalidApplicationPolicyExceptionException,AutoscalerServiceApplicationPolicyAlreadyExistsExceptionException {
+            AutoscalerServiceInvalidApplicationPolicyExceptionException, AutoscalerServiceApplicationPolicyAlreadyExistsExceptionException {
 
         if (applicationPolicyBean == null) {
             String msg = "Application policy bean is null";
@@ -3170,7 +3170,27 @@ public class StratosApiV41Utils {
         int tenantId;
         try {
             tenantId = tenantManager.getTenantId(tenantDomain);
+            if (tenantId != -1) {
+                try {
+                    TenantMgtUtil.deactivateTenant(tenantDomain, tenantManager, tenantId);
+                } catch (Exception e) {
+                    String msg = "Error in deactivating Tenant :" + tenantDomain;
+                    log.error(msg, e);
+                    throw new RestAPIException(msg, e);
+                }
 
+                //Notify tenant deactivation all listeners
+                try {
+                    TenantMgtUtil.triggerTenantDeactivation(tenantId);
+                } catch (StratosException e) {
+                    String msg = "Error in notifying tenant deactivate.";
+                    log.error(msg, e);
+                    throw new RestAPIException(msg, e);
+                }
+            } else {
+                String msg = "The tenant with domain name: " + tenantDomain + " does not exist.";
+                throw new RestAPIException(msg);
+            }
         } catch (UserStoreException e) {
             String msg = "Error in retrieving the tenant id for the tenant domain: " +
                     tenantDomain + ".";
@@ -3179,22 +3199,6 @@ public class StratosApiV41Utils {
 
         }
 
-        try {
-            TenantMgtUtil.deactivateTenant(tenantDomain, tenantManager, tenantId);
-        } catch (Exception e) {
-            String msg = "Error in deactivating Tenant :" + tenantDomain;
-            log.error(msg, e);
-            throw new RestAPIException(msg, e);
-        }
-
-        //Notify tenant deactivation all listeners
-        try {
-            TenantMgtUtil.triggerTenantDeactivation(tenantId);
-        } catch (StratosException e) {
-            String msg = "Error in notifying tenant deactivate.";
-            log.error(msg, e);
-            throw new RestAPIException(msg, e);
-        }
 
     }
 

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -3150,7 +3150,7 @@ public class StratosApiV41Utils {
                 }
             } else {
                 String msg = "The tenant with domain name: " + tenantDomain + " does not exist.";
-                throw new RestAPIException(msg);
+                throw new InvalidDomainException(msg);
             }
         } catch (UserStoreException e) {
             String msg = "Error in retrieving the tenant id for the tenant domain: " + tenantDomain + ".";
@@ -3189,7 +3189,7 @@ public class StratosApiV41Utils {
                 }
             } else {
                 String msg = "The tenant with domain name: " + tenantDomain + " does not exist.";
-                throw new RestAPIException(msg);
+                throw new InvalidDomainException(msg);
             }
         } catch (UserStoreException e) {
             String msg = "Error in retrieving the tenant id for the tenant domain: " +


### PR DESCRIPTION
fixed deactivating non-exist tenant in cli. In the current implementation it doesn't check for the existence of the tenant. Tenant id becomes -1 for non exist tenant.