### PR TITLE
Validating deployment policy removal

### DIFF
--- a/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/client/AutoscalerServiceClient.java
+++ b/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/client/AutoscalerServiceClient.java
@@ -217,7 +217,8 @@ public class AutoscalerServiceClient {
     }
 
     public void removeDeploymentPolicy(String deploymentPolicyID) throws RemoteException,
-            AutoscalerServiceDeploymentPolicyNotExistsExceptionException {
+            AutoscalerServiceDeploymentPolicyNotExistsExceptionException,
+            AutoscalerServiceUnremovablePolicyExceptionException {
         stub.removeDeployementPolicy(deploymentPolicyID);
     }
 

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41.java
@@ -271,12 +271,14 @@ public class StratosApiV41 extends AbstractApi {
     @AuthorizationAction("/permission/admin/manage/removeDeploymentPolicy")
     public Response removeDeploymentPolicy(
             @PathParam("deploymentPolicyId") String deploymentPolicyId) throws RestAPIException {
-
         try {
             StratosApiV41Utils.removeDeploymentPolicy(deploymentPolicyId);
         } catch (AutoscalerServiceDeploymentPolicyNotExistsExceptionException e) {
             return Response.status(Response.Status.NOT_FOUND).entity(new ResponseMessageBean(
                     ResponseMessageBean.ERROR, "Deployment policy not found")).build();
+        } catch (AutoscalerServiceUnremovablePolicyExceptionException e) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(new ResponseMessageBean(
+                    ResponseMessageBean.ERROR, "Deployment policy is in use")).build();
         }
         URI url = uriInfo.getAbsolutePathBuilder().path(deploymentPolicyId).build();
         return Response.ok(url).entity(new ResponseMessageBean(ResponseMessageBean.SUCCESS,

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -2766,7 +2766,8 @@ public class StratosApiV41Utils {
      * @throws RestAPIException
      */
     public static void removeDeploymentPolicy(String deploymentPolicyID)
-            throws RestAPIException, AutoscalerServiceDeploymentPolicyNotExistsExceptionException {
+            throws RestAPIException, AutoscalerServiceDeploymentPolicyNotExistsExceptionException,
+            AutoscalerServiceUnremovablePolicyExceptionException {
         try {
             AutoscalerServiceClient.getInstance().removeDeploymentPolicy(deploymentPolicyID);
         } catch (RemoteException e) {


### PR DESCRIPTION
Validating deployment policy removal. Deployment policy should not be allowed to remove when it is used in an application.