### PR TITLE
Setting the correct icons in console UI

### DIFF
--- a/components/org.apache.stratos.manager.console/console/controllers/menu/menu.json
+++ b/components/org.apache.stratos.manager.console/console/controllers/menu/menu.json
@@ -126,7 +126,7 @@
             "linkexternal": true,
             "context": "/",
             "title": "Documentation",
-            "icon": "fa-life-saver",
+            "icon": "fa-book",
             "permissionPaths": ["/permission", "/permission/admin"],
             "description": "Read documentation to get more information."
         }

--- a/components/org.apache.stratos.manager.console/console/themes/theme0/partials/applications_form.hbs
+++ b/components/org.apache.stratos.manager.console/console/themes/theme0/partials/applications_form.hbs
@@ -110,7 +110,7 @@
                     {{#each content_body.sections}}
                         <div class="block col-md-4 grid-group-item border-right">
                             <div class="toggle-menu-icon">
-                                <i class="fa fa-th-large"></i>
+                                <i class="fa fa-cubes"></i>
                             </div>
                             <h2 class="truncate">{{applicationId}} </h2>
 

--- a/components/org.apache.stratos.manager.console/console/themes/theme0/partials/configure_form.hbs
+++ b/components/org.apache.stratos.manager.console/console/themes/theme0/partials/configure_form.hbs
@@ -146,7 +146,7 @@
             {{#each content_body.sections}}
                 <div class="block col-md-4 grid-group-item border-right">
                     <div class="toggle-menu-icon">
-                        <i class="fa fa-gears "></i>
+                        <i class="fa fa-sitemap "></i>
                     </div>
                     <h2 class="truncate">{{clusterId}} </h2>
 
@@ -250,7 +250,7 @@
             {{#each content_body.sections}}
                 <div class="block col-md-4 col-xs-4 grid-group-item border-right">
                     <div class="toggle-menu-icon">
-                        <i class="fa fa-expand "></i>
+                        <i class="fa fa-th-large "></i>
                     </div>
                     <h2 class="truncate">{{id}} </h2>
 
@@ -284,7 +284,7 @@
             {{#each content_body.sections}}
                 <div class="block col-md-4 col-xs-4 grid-group-item border-right">
                     <div class="toggle-menu-icon">
-                        <i class="fa fa-expand "></i>
+                        <i class="fa fa-road "></i>
                     </div>
                     <h2 class="truncate">{{id}} </h2>
 
@@ -318,7 +318,7 @@
             {{#each content_body.sections}}
                 <div class="block col-md-4 grid-group-item border-right">
                     <div class="toggle-menu-icon">
-                        <i class="fa fa-th-large"></i>
+                        <i class="fa fa-cube"></i>
                     </div>
                     <h2 class="truncate">{{id}} </h2>
 
@@ -352,7 +352,7 @@
             {{#each content_body.sections}}
                 <div class="block col-md-4 grid-group-item border-right">
                     <div class="toggle-menu-icon">
-                        <i class="fa fa-th-large"></i>
+                        <i class="fa fa-briefcase"></i>
                     </div>
                     <h2 class="truncate">{{name}} </h2>
 


### PR DESCRIPTION
Correcting the icons in the listing pages of
* network-partition
* deployment-policy
* application-policy
* cartridge-group
* kubernetes-cluster
* applications

Changing the documentation icon in the menu