### PR TITLE
Group validation for deployment policies defined 

### DIFF
--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -1580,7 +1580,7 @@ public class StratosApiV41Utils {
     /**
      * This method validates cartridges in groups
      * Deployment policy should not defined in cartridge if group has a deployment policy
-     *
+     * If group does not have a DP, then cartridge should have one
      * @param cartridgeReferenceBeans - Cartridges in a group
      * @throws RestAPIException
      */

--- a/samples/applications/complex/php-tomcat-group-postgres-mysql-group-esb/artifacts/application.json
+++ b/samples/applications/complex/php-tomcat-group-postgres-mysql-group-esb/artifacts/application.json
@@ -21,7 +21,7 @@
                                 "repoUsername": "user"
                             },
                             "autoscalingPolicy": "autoscaling-policy-1",
-                            "deploymentPolicy": "deployment-policy-2"
+                            "deploymentPolicy": "deployment-policy-1"
                         }
                     },
                     {
@@ -37,7 +37,7 @@
                                 "repoUsername": "user"
                             },
                             "autoscalingPolicy": "autoscaling-policy-1",
-                            "deploymentPolicy": "deployment-policy-2"
+                            "deploymentPolicy": "deployment-policy-1"
                         }
                     }
                 ],
@@ -63,7 +63,7 @@
                                 "repoUsername": "user"
                             },
                             "autoscalingPolicy": "autoscaling-policy-1",
-                            "deploymentPolicy": "deployment-policy-2"
+                            "deploymentPolicy": "deployment-policy-1"
                         }
                     },
                     {
@@ -80,7 +80,7 @@
                                 "repoUsername": "user"
                             },
                             "autoscalingPolicy": "autoscaling-policy-1",
-                            "deploymentPolicy": "deployment-policy-2"
+                            "deploymentPolicy": "deployment-policy-1"
                         }
                     }
                 ],
@@ -103,7 +103,7 @@
                         "repoUsername": "user"
                     },
                     "autoscalingPolicy": "autoscaling-policy-1",
-                    "deploymentPolicy": "deployment-policy-2"
+                    "deploymentPolicy": "deployment-policy-1"
                 }
             }
         ],

--- a/samples/applications/complex/wordpress-app/artifacts/application.json
+++ b/samples/applications/complex/wordpress-app/artifacts/application.json
@@ -15,7 +15,7 @@
                         "cartridgeMax": 5,
                         "subscribableInfo": {
                             "alias": "my-mysql",
-                            "deploymentPolicy": "deployment-policy-2",
+                            "deploymentPolicy": "deployment-policy-1",
                             "autoscalingPolicy": "autoscaling-policy-1"
                         }
                     },
@@ -25,7 +25,7 @@
                         "cartridgeMax": 5,
                         "subscribableInfo": {
                             "alias": "my-php",
-                            "deploymentPolicy": "deployment-policy-2",
+                            "deploymentPolicy": "deployment-policy-1",
                             "autoscalingPolicy": "autoscaling-policy-1",
                             "artifactRepository": {
                                 "privateRepo": false,

--- a/samples/applications/simple/single-group-app/artifacts/application.json
+++ b/samples/applications/simple/single-group-app/artifacts/application.json
@@ -17,7 +17,6 @@
                         "subscribableInfo": {
                             "alias": "my-esb",
                             "autoscalingPolicy": "autoscaling-policy-1",
-                            "deploymentPolicy": "deployment-policy-1",
                             "artifactRepository": {
                                 "privateRepo": false,
                                 "repoUrl": "https://github.com/imesh/stratos-esb-applications.git",
@@ -33,7 +32,6 @@
                         "subscribableInfo": {
                             "alias": "my-php",
                             "autoscalingPolicy": "autoscaling-policy-1",
-                            "deploymentPolicy": "deployment-policy-1",
                             "artifactRepository": {
                                 "privateRepo": false,
                                 "repoUrl": "https://github.com/imesh/stratos-php-applications.git",


### PR DESCRIPTION
1. If the parent group has a deployment policy, all the child groups and cartridges will inherit that. So we should not define deployment policies in lower level.

2. If the parent group does not have a deployment policy, all the cartridges should have a deployment policy. So we need to define the deployment policy in subscribableInfo section in the cartridge. 