### PR TITLE
Removing UUID and tenantId from KubernetesClusterBean and ApplicationBean

### DIFF
--- a/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/RestCommandLineService.java
+++ b/components/org.apache.stratos.cli/src/main/java/org/apache/stratos/cli/RestCommandLineService.java
@@ -990,7 +990,7 @@ public class RestCommandLineService {
             RowMapper<ApplicationBean> rowMapper = new RowMapper<ApplicationBean>() {
                 public String[] getData(ApplicationBean applicationDefinition) {
                     String[] data = new String[3];
-                    data[0] = applicationDefinition.getApplicationUuid();
+                    data[0] = applicationDefinition.getApplicationId();
                     data[1] = applicationDefinition.getAlias();
                     data[2] = applicationDefinition.getStatus();
                     return data;
@@ -1146,7 +1146,7 @@ public class RestCommandLineService {
                 RowMapper<KubernetesClusterBean> partitionMapper = new RowMapper<KubernetesClusterBean>() {
                     public String[] getData(KubernetesClusterBean kubernetesCluster) {
                         String[] data = new String[2];
-                        data[0] = kubernetesCluster.getClusterUuid();
+                        data[0] = kubernetesCluster.getClusterId();
                         data[1] = kubernetesCluster.getDescription();
                         return data;
                     }

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/services/impl/CloudControllerServiceImpl.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/services/impl/CloudControllerServiceImpl.java
@@ -798,7 +798,6 @@ public class CloudControllerServiceImpl implements CloudControllerService {
     public Cartridge[] getCartridgesByTenant(int tenantId) {
 
         Collection<Cartridge> allCartridges = CloudControllerContext.getInstance().getCartridges();
-        log.info("---------------------------- All cartridges: "+ allCartridges);
         List<Cartridge> cartridges = new ArrayList<Cartridge>();
         if (allCartridges == null || allCartridges.size() == 0) {
             log.info("No registered Cartridge found for [tenant-id]" + tenantId);
@@ -813,7 +812,6 @@ public class CloudControllerServiceImpl implements CloudControllerService {
             }
         }
 
-        log.info("---------------------------- Cartridges for tenant: "+ cartridges);
         return cartridges.toArray(new Cartridge[cartridges.size()]);
     }
 

--- a/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/beans/application/ApplicationBean.java
+++ b/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/beans/application/ApplicationBean.java
@@ -30,7 +30,6 @@ public class ApplicationBean implements Serializable {
 
     private static final long serialVersionUID = -2829206180707597651L;
 
-    private String applicationUuid;
 	private String applicationId;
     private boolean multiTenant;
     private String name;
@@ -39,15 +38,6 @@ public class ApplicationBean implements Serializable {
     private String status;
     private ComponentBean components;
     private List<PropertyBean> property;
-	private int tenantId;
-
-    public String getApplicationUuid() {
-        return applicationUuid;
-    }
-
-    public void setApplicationUuid(String applicationUuid) {
-        this.applicationUuid = applicationUuid;
-    }
 
     public boolean isMultiTenant() {
         return multiTenant;
@@ -104,14 +94,6 @@ public class ApplicationBean implements Serializable {
     public void setProperty(List<PropertyBean> property) {
         this.property = property;
     }
-
-	public int getTenantId() {
-		return tenantId;
-	}
-
-	public void setTenantId(int tenantId) {
-		this.tenantId = tenantId;
-	}
 
 	public String getApplicationId() {
 		return applicationId;

--- a/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/beans/kubernetes/KubernetesClusterBean.java
+++ b/components/org.apache.stratos.common/src/main/java/org/apache/stratos/common/beans/kubernetes/KubernetesClusterBean.java
@@ -27,22 +27,12 @@ import java.util.List;
 @XmlRootElement
 public class KubernetesClusterBean {
 
-    private String clusterUuid;
 	private String clusterId;
     private String description;
     private List<KubernetesHostBean> kubernetesHosts;
     private KubernetesMasterBean kubernetesMaster;
     private PortRangeBean portRange;
     private List<PropertyBean> property;
-	private int tenantId;
-
-    public String getClusterUuid() {
-        return clusterUuid;
-    }
-
-    public void setClusterUuid(String clusterUuid) {
-        this.clusterUuid = clusterUuid;
-    }
 
     public List<KubernetesHostBean> getKubernetesHosts() {
         return kubernetesHosts;
@@ -90,13 +80,5 @@ public class KubernetesClusterBean {
 
 	public void setClusterId(String clusterId) {
 		this.clusterId = clusterId;
-	}
-
-	public int getTenantId() {
-		return tenantId;
-	}
-
-	public void setTenantId(int tenantId) {
-		this.tenantId = tenantId;
 	}
 }

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -1026,7 +1026,7 @@ public class StratosApiV41Utils {
         }
 
         List<String> cartridgeTypes = new ArrayList<String>();
-        String[] cartridgeUuids = null;
+        String[] cartridgeUuids;
         List<String> groupNames;
         String[] cartridgeGroupNames;
 
@@ -1332,7 +1332,7 @@ public class StratosApiV41Utils {
         if (log.isDebugEnabled()) {
             log.debug(String.format("Removing cartridge group: [cartridge-group-name] %s [tenant-id] %d " ,name,tenantId));
         }
-        String serviceGroupUuid = null;
+        String serviceGroupUuid;
         // Check whether cartridge group exists
         try {
 
@@ -1670,11 +1670,7 @@ public class StratosApiV41Utils {
 
                 // Validate top level group deployment policy with cartridges
                 if (group.getCartridges() != null) {
-                    if (group.getDeploymentPolicy() != null) {
-                        groupParentHasDeploymentPolicy = true;
-                    } else {
-                        groupParentHasDeploymentPolicy = false;
-                    }
+                    groupParentHasDeploymentPolicy = group.getDeploymentPolicy() != null;
                     validateCartridgesForDeploymentPolicy(group.getCartridges(), groupParentHasDeploymentPolicy);
                 }
 
@@ -1740,7 +1736,7 @@ public class StratosApiV41Utils {
                                                   Collection<CartridgeGroupReferenceBean> groups, boolean hasDeploymentPolicy)
             throws RestAPIException {
 
-        boolean groupHasDeploymentPolicy = false;
+        boolean groupHasDeploymentPolicy;
 
         for (CartridgeGroupReferenceBean group : groups) {
             if (groupsSet.get(group.getAlias()) != null) {
@@ -2007,8 +2003,8 @@ public class StratosApiV41Utils {
     public static ApplicationInfoBean getApplicationRuntime(String applicationId,int tenantId)
             throws RestAPIException {
         ApplicationInfoBean applicationBean = null;
-        ApplicationContext applicationContext = null;
-        String applicationUuid=null;
+        ApplicationContext applicationContext;
+        String applicationUuid;
         //Checking whether application is in deployed mode
         try {
             applicationUuid=getAutoscalerServiceClient().getApplicationByTenant(applicationId,tenantId).getApplicationUuid();
@@ -2029,13 +2025,13 @@ public class StratosApiV41Utils {
         try {
             ApplicationManager.acquireReadLockForApplication(applicationUuid);
             Application application = ApplicationManager.getApplications().getApplication(applicationUuid);
+            if (application == null) {
+                return null;
+            }
             if (application.getInstanceContextCount() > 0
                     || (applicationContext != null &&
                     applicationContext.getStatus().equals("Deployed"))) {
 
-                if (application == null) {
-                    return null;
-                }
                 applicationBean = ObjectConverter.convertApplicationToApplicationInstanceBean(application);
                 for (ApplicationInstanceBean instanceBean : applicationBean.getApplicationInstances()) {
                     addClustersInstancesToApplicationInstanceBean(instanceBean, application);

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/util/converter/ObjectConverter.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/util/converter/ObjectConverter.java
@@ -939,22 +939,23 @@ public class ObjectConverter {
     }
 
     public static org.apache.stratos.cloud.controller.stub.domain.kubernetes.KubernetesCluster
-    convertToCCKubernetesClusterPojo(KubernetesClusterBean kubernetesClusterBean) throws RestAPIException {
+    convertToCCKubernetesClusterPojo(KubernetesClusterBean kubernetesClusterBean, String kubernetesClusterUuid,
+                                     int tenantId) throws RestAPIException {
 
         org.apache.stratos.cloud.controller.stub.domain.kubernetes.KubernetesCluster kubernetesCluster = new
                 org.apache.stratos.cloud.controller.stub.domain.kubernetes.KubernetesCluster();
 
-        kubernetesCluster.setClusterUuid(kubernetesClusterBean.getClusterUuid());
+        kubernetesCluster.setClusterUuid(kubernetesClusterUuid);
         kubernetesCluster.setClusterId(kubernetesClusterBean.getClusterId());
         kubernetesCluster.setDescription(kubernetesClusterBean.getDescription());
         kubernetesCluster.setKubernetesMaster(convertStubKubernetesMasterToKubernetesMaster(
-                kubernetesClusterBean.getKubernetesMaster(),kubernetesClusterBean.getTenantId()));
+                kubernetesClusterBean.getKubernetesMaster(), tenantId));
         kubernetesCluster.setPortRange(convertPortRangeToStubPortRange(kubernetesClusterBean.getPortRange()));
         kubernetesCluster.setKubernetesHosts(convertToASKubernetesHostsPojo(kubernetesClusterBean.getKubernetesHosts(),
-                kubernetesClusterBean.getTenantId()));
+                tenantId));
         kubernetesCluster.setProperties((convertPropertyBeansToCCStubProperties(kubernetesClusterBean.getProperty(),
-                kubernetesClusterBean.getTenantId())));
-        kubernetesCluster.setTenantId(kubernetesClusterBean.getTenantId());
+                tenantId)));
+        kubernetesCluster.setTenantId(tenantId);
 
         return kubernetesCluster;
     }
@@ -1045,7 +1046,7 @@ public class ObjectConverter {
             return null;
         }
         KubernetesClusterBean kubernetesClusterBean = new KubernetesClusterBean();
-        kubernetesClusterBean.setClusterUuid(kubernetesCluster.getClusterId());
+        kubernetesClusterBean.setClusterId(kubernetesCluster.getClusterId());
         kubernetesClusterBean.setDescription(kubernetesCluster.getDescription());
         kubernetesClusterBean.setPortRange(convertStubPortRangeToPortRange(kubernetesCluster.getPortRange()));
         kubernetesClusterBean.setKubernetesHosts(convertStubKubernetesHostsToKubernetesHosts(kubernetesCluster.getKubernetesHosts()));
@@ -1132,18 +1133,18 @@ public class ObjectConverter {
     }
 
     public static ApplicationContext convertApplicationDefinitionToStubApplicationContext(
-            ApplicationBean applicationDefinition) throws RestAPIException {
+            ApplicationBean applicationDefinition, String applicationUuid, int tenantId) throws RestAPIException {
 
         org.apache.stratos.autoscaler.stub.pojo.ApplicationContext applicationContext =
                 new org.apache.stratos.autoscaler.stub.pojo.ApplicationContext();
-        applicationContext.setApplicationUuid(applicationDefinition.getApplicationUuid());
+        applicationContext.setApplicationUuid(applicationUuid);
         applicationContext.setApplicationId(applicationDefinition.getApplicationId());
         applicationContext.setAlias(applicationDefinition.getAlias());
         applicationContext.setMultiTenant(applicationDefinition.isMultiTenant());
         applicationContext.setName(applicationDefinition.getName());
         applicationContext.setDescription(applicationDefinition.getDescription());
         applicationContext.setStatus(applicationDefinition.getStatus());
-        applicationContext.setTenantId(applicationDefinition.getTenantId());
+        applicationContext.setTenantId(tenantId);
 
         // convert and set components
         if (applicationDefinition.getComponents() != null) {
@@ -1154,7 +1155,7 @@ public class ObjectConverter {
             if (applicationDefinition.getComponents().getGroups() != null) {
                 componentContext.setGroupContexts(
                         convertGroupDefinitionsToStubGroupContexts(applicationDefinition.getComponents().getGroups(),
-                                applicationDefinition.getTenantId()));
+                                tenantId));
             }
             // top level dependency information
             if (applicationDefinition.getComponents().getDependencies() != null) {
@@ -1164,7 +1165,7 @@ public class ObjectConverter {
             // top level cartridge context information
             if (applicationDefinition.getComponents().getCartridges() != null) {
                 componentContext.setCartridgeContexts(convertCartridgeReferenceBeansToStubCartridgeContexts
-                        (applicationDefinition.getComponents().getCartridges(), applicationDefinition.getTenantId()));
+                        (applicationDefinition.getComponents().getCartridges(), tenantId));
             }
             applicationContext.setComponents(componentContext);
         }
@@ -1178,14 +1179,12 @@ public class ObjectConverter {
         }
 
         ApplicationBean applicationDefinition = new ApplicationBean();
-        applicationDefinition.setApplicationUuid(applicationContext.getApplicationUuid());
         applicationDefinition.setApplicationId(applicationContext.getApplicationId());
         applicationDefinition.setAlias(applicationContext.getAlias());
         applicationDefinition.setMultiTenant(applicationContext.getMultiTenant());
         applicationDefinition.setName(applicationContext.getName());
         applicationDefinition.setDescription(applicationContext.getDescription());
         applicationDefinition.setStatus(applicationContext.getStatus());
-        applicationDefinition.setApplicationUuid(applicationContext.getApplicationUuid());
         // convert and set components
         if (applicationContext.getComponents() != null) {
             applicationDefinition.setComponents(new ComponentBean());
@@ -1536,7 +1535,6 @@ public class ObjectConverter {
         return prop;
     }
 
-
     private static DependencyContext convertDependencyDefinitionsToDependencyContexts(DependencyBean dependencyBean) {
         if (dependencyBean == null) {
             return null;
@@ -1734,8 +1732,8 @@ public class ObjectConverter {
         }
 
         ApplicationInfoBean applicationBean = new ApplicationInfoBean();
-        applicationBean.setId(application.getUniqueIdentifier());
-        applicationBean.setName(application.getId());
+        applicationBean.setId(application.getId());
+        applicationBean.setName(application.getName());
         applicationBean.setStatus(application.getStatus().name());
         applicationBean.setDescription(application.getDescription());
         applicationBean.setTenantDomain(application.getTenantDomain());

--- a/products/stratos/modules/integration/src/test/java/org/apache/stratos/integration/tests/SampleApplicationsTest.java
+++ b/products/stratos/modules/integration/src/test/java/org/apache/stratos/integration/tests/SampleApplicationsTest.java
@@ -442,13 +442,13 @@ public class SampleApplicationsTest extends StratosTestServerManager {
             assertEquals(deployed, true);
 
             //Application active handling
-            assertApplicationActivation(bean.getApplicationUuid());
+            assertApplicationActivation("g-sc-G123-1", -1234);
 
             //Group active handling
-            assertGroupActivation(bean.getApplicationUuid());
+            assertGroupActivation("g-sc-G123-1", -1234);
 
             //Cluster active handling
-            assertClusterActivation(bean.getApplicationUuid());
+            assertClusterActivation("g-sc-G123-1", -1234);
 
             //Updating application
           /*  boolean updated = applicationTest.updateApplication("g-sc-G123-1.json",
@@ -481,7 +481,7 @@ public class SampleApplicationsTest extends StratosTestServerManager {
                     restClient);
             assertEquals(unDeployed, true);
 
-            assertApplicationUndeploy(bean.getApplicationUuid());
+            assertApplicationUndeploy("g-sc-G123-1", -1234);
 
             boolean removed = applicationTest.removeApplication("g-sc-G123-1", endpoint,
                     restClient);
@@ -773,7 +773,7 @@ public class SampleApplicationsTest extends StratosTestServerManager {
 
     private void runApplicationTest(String applicationFolderName, String applicationId) {
         executeCommand(getApplicationsPath() + "/" + applicationFolderName + "/scripts/mock/deploy.sh");
-        assertApplicationActivation(applicationId);
+        assertApplicationActivation(applicationId, -1234);
         executeCommand(getApplicationsPath() + "/" + applicationFolderName + "/scripts/mock/undeploy.sh");
         assertApplicationNotExists(applicationId);
     }
@@ -825,35 +825,35 @@ public class SampleApplicationsTest extends StratosTestServerManager {
     /**
      * Assert application activation
      *
-     * @param applicationUuid
+     * @param applicationId
      */
-    private void assertApplicationActivation(String applicationUuid) {
+    private void assertApplicationActivation(String applicationId, int tenantId) {
         long startTime = System.currentTimeMillis();
-        Application application = ApplicationManager.getApplications().getApplication(applicationUuid);
+        Application application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
         while (!((application != null) && (application.getStatus() == ApplicationStatus.Active))) {
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException ignore) {
             }
-            application = ApplicationManager.getApplications().getApplication(applicationUuid);
+            application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
             if ((System.currentTimeMillis() - startTime) > APPLICATION_ACTIVATION_TIMEOUT) {
                 break;
             }
         }
-        assertNotNull(String.format("Application is not found: [application-id] %s", applicationUuid), application);
-        assertEquals(String.format("Application status did not change to active: [application-id] %s", applicationUuid),
+        assertNotNull(String.format("Application is not found: [application-id] %s", application.getId()), application);
+        assertEquals(String.format("Application status did not change to active: [application-id] %s", application.getId()),
                 ApplicationStatus.Active, application.getStatus());
     }
 
     /**
      * Assert application activation
      *
-     * @param applicationUuid
+     * @param applicationId
      */
-    private void assertGroupActivation(String applicationUuid) {
-        Application application = ApplicationManager.getApplications().getApplication(applicationUuid);
+    private void assertGroupActivation(String applicationId, int tenantId) {
+        Application application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
         assertNotNull(String.format("Application is not found: [application-id] %s",
-                applicationUuid), application);
+                applicationId), application);
 
         Collection<Group> groups = application.getAllGroupsRecursively();
         for(Group group : groups) {
@@ -864,12 +864,12 @@ public class SampleApplicationsTest extends StratosTestServerManager {
     /**
      * Assert application activation
      *
-     * @param applicationUuid
+     * @param applicationId
      */
-    private void assertClusterActivation(String applicationUuid) {
-        Application application = ApplicationManager.getApplications().getApplication(applicationUuid);
+    private void assertClusterActivation(String applicationId, int tenantId) {
+        Application application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
         assertNotNull(String.format("Application is not found: [application-id] %s",
-                applicationUuid), application);
+                applicationId), application);
 
         Set<ClusterDataHolder> clusterDataHolderSet = application.getClusterDataRecursively();
         for(ClusterDataHolder clusterDataHolder : clusterDataHolderSet) {
@@ -877,11 +877,11 @@ public class SampleApplicationsTest extends StratosTestServerManager {
             String clusterId = clusterDataHolder.getClusterId();
             Service service = TopologyManager.getTopology().getService(serviceUuid);
             assertNotNull(String.format("Service is not found: [application-id] %s [service] %s",
-                    applicationUuid, serviceUuid), service);
+                    applicationId, serviceUuid), service);
 
             Cluster cluster = service.getCluster(clusterId);
             assertNotNull(String.format("Cluster is not found: [application-id] %s [service] %s [cluster-id] %s",
-                    applicationUuid, serviceUuid, clusterId), cluster);
+                    applicationId, serviceUuid, clusterId), cluster);
             boolean clusterActive = false;
 
             for (ClusterInstance instance : cluster.getInstanceIdToInstanceContextMap().values()) {
@@ -911,16 +911,16 @@ public class SampleApplicationsTest extends StratosTestServerManager {
     /**
      * Assert application activation
      *
-     * @param applicationUuid
+     * @param applicationId
      */
-    private void assertApplicationUndeploy(String applicationUuid) {
+    private void assertApplicationUndeploy(String applicationId, int tenantId) {
         long startTime = System.currentTimeMillis();
-        Application application = ApplicationManager.getApplications().getApplication(applicationUuid);
+        Application application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
         ApplicationContext applicationContext = null;
         try {
-            applicationContext = AutoscalerServiceClient.getInstance().getApplication(applicationUuid);
+            applicationContext = AutoscalerServiceClient.getInstance().getApplicationByTenant(applicationId, tenantId);
         } catch (RemoteException e) {
-            log.error("Error while getting the application context for [application] " + applicationUuid);
+            log.error("Error while getting the application context for [application] " + applicationId);
         }
         while (((application != null) && application.getInstanceContextCount() > 0) ||
                 (applicationContext == null || applicationContext.getStatus().equals(APPLICATION_STATUS_UNDEPLOYING))) {
@@ -928,41 +928,40 @@ public class SampleApplicationsTest extends StratosTestServerManager {
                 Thread.sleep(1000);
             } catch (InterruptedException ignore) {
             }
-            application = ApplicationManager.getApplications().getApplication(applicationUuid);
+            application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
             try {
-                applicationContext = AutoscalerServiceClient.getInstance().getApplication(applicationUuid);
+                applicationContext = AutoscalerServiceClient.getInstance().getApplicationByTenant(applicationId, tenantId);
             } catch (RemoteException e) {
-                log.error("Error while getting the application context for [application] " + applicationUuid);
+                log.error("Error while getting the application context for [application] " + applicationId);
             }
             if ((System.currentTimeMillis() - startTime) > APPLICATION_ACTIVATION_TIMEOUT) {
                 break;
             }
         }
 
-        assertNotNull(String.format("Application is not found: [application-id] %s",
-                applicationUuid), application);
-        assertNotNull(String.format("Application Context is not found: [application-id] %s",
-                applicationUuid), applicationContext);
+        assertNotNull(String.format("Application is not found: [application-id] %s", applicationId), application);
+        assertNotNull(String.format("Application Context is not found: [application-id] %s", applicationId),
+                applicationContext);
 
         //Force undeployment after the graceful deployment
         if (application.getInstanceContextCount() > 0 ||
                 applicationContext.getStatus().equals(APPLICATION_STATUS_UNDEPLOYING)) {
-            log.info("Force undeployment is going to start for the [application] " + applicationUuid);
+            log.info("Force undeployment is going to start for the [application] " + applicationId);
 
-            applicationTest.forceUndeployApplication(applicationUuid, endpoint, restClient);
+            applicationTest.forceUndeployApplication(applicationId, endpoint, restClient);
             while (application.getInstanceContextCount() > 0 ||
                     applicationContext.getStatus().equals(APPLICATION_STATUS_UNDEPLOYING)) {
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException ignore) {
                 }
-                application = ApplicationManager.getApplications().getApplication(applicationUuid);
+                application = ApplicationManager.getApplications().getApplicationByTenant(applicationId, tenantId);
                 if ((System.currentTimeMillis() - startTime) > APPLICATION_ACTIVATION_TIMEOUT) {
                     break;
                 }
             }
         }
-        assertEquals(String.format("Application status did not change to Created: [application-id] %s", applicationUuid),
+        assertEquals(String.format("Application status did not change to Created: [application-id] %s", applicationId),
                 APPLICATION_STATUS_CREATED, applicationContext.getStatus());
 
     }


### PR DESCRIPTION
Removing UUID and tenantId from KubernetesClusterBean and ApplicationBean