### PR TITLE
Adding kubernetes services to member initialized event

### DIFF
--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/iaases/kubernetes/KubernetesIaas.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/iaases/kubernetes/KubernetesIaas.java
@@ -556,6 +556,7 @@ public class KubernetesIaas extends Iaas {
                 String[] minionPublicIPArray = minionPublicIPList.toArray(new String[minionPublicIPList.size()]);
                 kubernetesService.setPublicIPs(minionPublicIPArray);
                 kubernetesService.setProtocol(clusterPortMapping.getProtocol());
+                kubernetesService.setPortName(clusterPortMapping.getName());
 
                 String kubernetesServiceType = service.getSpec().getType();
                 kubernetesService.setServiceType(kubernetesServiceType);

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
@@ -451,6 +451,16 @@ public class TopologyBuilder {
                         MemberStatus.Initialized);
                 return;
             } else {
+
+                Cluster cluster = service.getCluster(memberContext.getClusterId());
+                String clusterId = cluster.getClusterId();
+                ClusterContext clusterContext = CloudControllerContext.getInstance().getClusterContext(clusterId);
+                List<KubernetesService> kubernetesServices = clusterContext.getKubernetesServices();
+
+                if (kubernetesServices != null) {
+                    cluster.setKubernetesServices(kubernetesServices);
+                }
+
                 member.setStatus(MemberStatus.Initialized);
                 log.info("Member status updated to initialized");
 
@@ -844,11 +854,9 @@ public class TopologyBuilder {
         try {
             TopologyManager.acquireWriteLock();
             List<KubernetesService> kubernetesServices = clusterContext.getKubernetesServices();
-            cluster.setKubernetesServices(kubernetesServices);
 
             if (kubernetesServices != null) {
-                // Set kubernetes services
-                cluster.setKubernetesServices(kubernetesServices);
+               
                 try {
                     // Generate access URLs for kubernetes services
                     for (KubernetesService kubernetesService : kubernetesServices) {

--- a/components/org.apache.stratos.messaging/src/main/java/org/apache/stratos/messaging/domain/topology/KubernetesService.java
+++ b/components/org.apache.stratos.messaging/src/main/java/org/apache/stratos/messaging/domain/topology/KubernetesService.java
@@ -35,7 +35,15 @@ public class KubernetesService implements Serializable {
     private int port;
     private int containerPort;
     private String serviceType;
+    private String portName;
 
+    public String getPortName() {
+        return portName;
+    }
+
+    public void setPortName(String portName) {
+        this.portName = portName;
+    }
     public String getServiceType() {
         return serviceType;
     }


### PR DESCRIPTION
At the moment we send kubernetes services we have created for particular cartridge (or service) at the cluster activated event. Therefore at the complete topology we can't get already created kubernetes service for a cartridge. So with this change I am sending those details in the member initialized event so that it will be available for the complete topology event. Added port name property to kubernetes service, so that the port can be identified uniquely. 

Changes I have done
- Added kubernetes services to member initialized event 
- Remove adding kubernetes services from cluster activated event
- Added portName property to kubernetes service