### PR TITLE
Cleaning and Formatting

### DIFF
--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/config/CloudControllerConfig.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/config/CloudControllerConfig.java
@@ -19,8 +19,6 @@
 
 package org.apache.stratos.cloud.controller.config;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.stratos.cloud.controller.domain.DataPublisherConfig;
 import org.apache.stratos.cloud.controller.domain.IaasProvider;
 import org.apache.stratos.cloud.controller.domain.TopologyConfig;
@@ -32,8 +30,6 @@ import java.util.List;
  * the configuration in this singleton class to be used in the runtime.
  */
 public class CloudControllerConfig {
-
-    private static final Log log = LogFactory.getLog(CloudControllerConfig.class);
 
     private static volatile CloudControllerConfig instance;
 

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/config/parser/CloudControllerConfigParser.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/config/parser/CloudControllerConfigParser.java
@@ -50,10 +50,13 @@ public class CloudControllerConfigParser {
      */
     public static void parse(OMElement documentElement) throws MalformedConfigurationFileException {
 
-        extractIaasProviders(documentElement, AxiomXpathParserUtil.getMatchingNodes(documentElement, CloudControllerConstants.IAAS_PROVIDER_XPATH));
-        extractDataPublisherConfig(documentElement, AxiomXpathParserUtil.getElement(FILE_NAME, documentElement, CloudControllerConstants.DATA_PUBLISHER_ELEMENT,
+        extractIaasProviders(documentElement, AxiomXpathParserUtil.getMatchingNodes(
+                documentElement, CloudControllerConstants.IAAS_PROVIDER_XPATH));
+        extractDataPublisherConfig(documentElement, AxiomXpathParserUtil.getElement(
+                FILE_NAME, documentElement, CloudControllerConstants.DATA_PUBLISHER_ELEMENT,
                 CloudControllerConstants.DATA_PUBLISHER_XPATH));
-        extractTopologySyncConfig(documentElement, AxiomXpathParserUtil.getElement(FILE_NAME, documentElement, CloudControllerConstants.TOPOLOGY_SYNC_ELEMENT,
+        extractTopologySyncConfig(documentElement, AxiomXpathParserUtil.getElement(
+                FILE_NAME, documentElement, CloudControllerConstants.TOPOLOGY_SYNC_ELEMENT,
                 CloudControllerConstants.TOPOLOGY_SYNC_XPATH));
     }
 
@@ -132,22 +135,26 @@ public class CloudControllerConfigParser {
             }
 
             // set cassandra info
-            childElement = AxiomXpathParserUtil.getFirstChildElement(element, CloudControllerConstants.CASSANDRA_INFO_ELEMENT);
+            childElement = AxiomXpathParserUtil.getFirstChildElement(element,
+                    CloudControllerConstants.CASSANDRA_INFO_ELEMENT);
 
             if (childElement != null) {
                 // set connection url
-                elt = AxiomXpathParserUtil.getFirstChildElement(childElement, CloudControllerConstants.CONNECTION_URL_ELEMENT);
+                elt = AxiomXpathParserUtil.getFirstChildElement(childElement,
+                        CloudControllerConstants.CONNECTION_URL_ELEMENT);
                 if (elt != null) {
                     dataPublisherConfig.setCassandraConnUrl(elt.getText());
                 }
 
                 // set user name
-                elt = AxiomXpathParserUtil.getFirstChildElement(childElement, CloudControllerConstants.USER_NAME_ELEMENT);
+                elt = AxiomXpathParserUtil.getFirstChildElement(childElement,
+                        CloudControllerConstants.USER_NAME_ELEMENT);
                 if (elt != null) {
                     dataPublisherConfig.setCassandraUser(elt.getText());
                 }
                 // set password
-                elt = AxiomXpathParserUtil.getFirstChildElement(childElement, CloudControllerConstants.PASSWORD_ELEMENT);
+                elt = AxiomXpathParserUtil.getFirstChildElement(childElement,
+                        CloudControllerConstants.PASSWORD_ELEMENT);
                 if (elt != null) {
                     String password = AxiomXpathParserUtil.resolveSecret(documentElement, elt);
                     if (password == null) {

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/config/parser/IaasProviderConfigParser.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/config/parser/IaasProviderConfigParser.java
@@ -39,7 +39,8 @@ import java.util.Map;
 public class IaasProviderConfigParser {
     private static final Log log = LogFactory.getLog(IaasProviderConfigParser.class);
 
-    public static IaasProvider getIaasProvider(final String fileName, final OMElement elt, final OMNode item, List<IaasProvider> iaases) {
+    public static IaasProvider getIaasProvider(final String fileName, final OMElement elt,
+                                               final OMNode item, List<IaasProvider> iaases) {
 
         IaasProvider iaas = null;
 
@@ -128,7 +129,8 @@ public class IaasProviderConfigParser {
 
     }
 
-    private static void loadCredentials(final String fileName, final OMElement elt, final IaasProvider iaas, final OMElement iaasElt,
+    private static void loadCredentials(final String fileName, final OMElement elt, final IaasProvider iaas,
+                                        final OMElement iaasElt,
                                         final String xpath) {
 
         Iterator<?> it =
@@ -178,7 +180,8 @@ public class IaasProviderConfigParser {
     }
 
 
-    private static void loadIdentity(final String fileName, final OMElement elt, final IaasProvider iaas, final OMElement iaasElt) {
+    private static void loadIdentity(final String fileName, final OMElement elt, final IaasProvider iaas,
+                                     final OMElement iaasElt) {
 
         Iterator<?> it =
                 iaasElt.getChildrenWithName(new QName(CloudControllerConstants.IDENTITY_ELEMENT));
@@ -225,7 +228,8 @@ public class IaasProviderConfigParser {
     }
 
 
-    public static void loadProperties(final String fileName, final OMElement elt, final Map<String, String> propertyMap) {
+    public static void loadProperties(final String fileName, final OMElement elt,
+                                      final Map<String, String> propertyMap) {
 
         Iterator<?> it =
                 elt.getChildrenWithName(new QName(CloudControllerConstants.PROPERTY_ELEMENT));

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/iaases/PartitionValidator.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/iaases/PartitionValidator.java
@@ -34,7 +34,7 @@ public interface PartitionValidator {
      *
      * @param iaasProvider {@link IaasProvider}
      */
-    public abstract void setIaasProvider(IaasProvider iaasProvider);
+    void setIaasProvider(IaasProvider iaasProvider);
 
     /**
      * Validate the given properties for its existent in this partition.
@@ -44,5 +44,5 @@ public interface PartitionValidator {
      * @return cloned and modified {@link IaasProvider} which maps to the given partition.
      * @throws InvalidPartitionException if at least one property is evaluated to be invalid.
      */
-    public abstract IaasProvider validate(Partition partition, Properties properties) throws InvalidPartitionException;
+    IaasProvider validate(Partition partition, Properties properties) throws InvalidPartitionException;
 }

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/services/impl/CloudControllerServiceUtil.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/services/impl/CloudControllerServiceUtil.java
@@ -52,7 +52,7 @@ public class CloudControllerServiceUtil {
      * Update the topology, publish statistics to BAM, remove member context
      * and persist cloud controller context.
      *
-     * @param memberContext
+     * @param memberContext MemberContext of the Member
      */
     public static void executeMemberTerminationPostProcess(MemberContext memberContext) {
         if (memberContext == null) {
@@ -86,8 +86,7 @@ public class CloudControllerServiceUtil {
     }
 
     public static boolean isValidIpAddress(String ip) {
-        boolean isValid = InetAddresses.isInetAddress(ip);
-        return isValid;
+        return InetAddresses.isInetAddress(ip);
     }
 
     public static IaasProvider validatePartitionAndGetIaasProvider(Partition partition, IaasProvider iaasProvider)

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/util/CloudControllerConstants.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/util/CloudControllerConstants.java
@@ -18,67 +18,26 @@
  */
 package org.apache.stratos.cloud.controller.util;
 
-import org.wso2.carbon.utils.CarbonUtils;
-
-import java.io.File;
-
 public final class CloudControllerConstants {
 
     /**
      * cloud-controller XML file's elements
      */
     public static final String CLOUD_CONTROLLER_ELEMENT = "cloudController";
-    public static final String SERIALIZATION_DIR_ELEMENT = "serializationDir";
     public static final String IAAS_PROVIDERS_ELEMENT = "iaasProviders";
     public static final String IAAS_PROVIDER_ELEMENT = "iaasProvider";
-    public static final String PARTITION_ELEMENT = "partition";
-    public static final String PARTITIONS_ELEMENT = "partitions";
-    public static final String REGION_ELEMENT = "region";
     public static final String ZONE_ELEMENT = "zone";
-    public static final String DEPLOYMENT_ELEMENT = "deployment";
-    public static final String PORT_MAPPING_ELEMENT = "portMapping";
-    public static final String APP_TYPES_ELEMENT = "appTypes";
     public static final String TYPE_ATTR = "type";
-    public static final String HOST_ATTR = "host";
-    public static final String BASE_DIR_ATTR = "baseDir";
-    public static final String PROVIDER_ATTR = "provider";
-    public static final String VERSION_ATTR = "version";
-    public static final String MULTI_TENANT_ATTR = "multiTenant";
-    public static final String PORT_ATTR = "port";
-    public static final String PROXY_PORT_ATTR = "proxyPort";
     public static final String NAME_ATTR = "name";
-    public static final String APP_SPECIFIC_MAPPING_ATTR = "appSpecificMapping";
 
-    public static final String CARTRIDGES_ELEMENT = "cartridges";
-    public static final String CARTRIDGE_ELEMENT = "cartridge";
-
-    public static final String DISPLAY_NAME_ELEMENT = "displayName";
-    public static final String DESCRIPTION_ELEMENT = "description";
     public static final String PROPERTY_ELEMENT = "property";
     public static final String PROPERTY_NAME_ATTR = "name";
     public static final String PROPERTY_VALUE_ATTR = "value";
     public static final String IMAGE_ID_ELEMENT = "imageId";
-    public static final String SCALE_DOWN_ORDER_ELEMENT = "scaleDownOrder";
-    public static final String SCALE_UP_ORDER_ELEMENT = "scaleUpOrder";
     public static final String CLASS_NAME_ELEMENT = "className";
     public static final String PROVIDER_ELEMENT = "provider";
     public static final String IDENTITY_ELEMENT = "identity";
-    public static final String TYPE_ELEMENT = "type";
-    public static final String SCOPE_ELEMENT = "scope";
-    public static final String ID_ELEMENT = "id";
     public static final String CREDENTIAL_ELEMENT = "credential";
-    public static final String DEFAULT_SERVICE_ELEMENT = "default";
-    public static final String SERVICE_ELEMENT = "service";
-    public static final String SERVICES_ELEMENT = "services";
-    public static final String DIRECTORY_ELEMENT = "dir";
-    public static final String HTTP_ELEMENT = "http";
-    public static final String HTTPS_ELEMENT = "https";
-    public static final String APP_TYPE_ELEMENT = "appType";
-    public static final String SERVICE_DOMAIN_ATTR = "domain";
-    public static final String SERVICE_SUB_DOMAIN_ATTR = "subDomain";
-    public static final String SERVICE_TENANT_RANGE_ATTR = "tenantRange";
-    public static final String POLICY_NAME = "policyName";
-    public static final String PAYLOAD_ELEMENT = "payload";
     public static final String DATA_PUBLISHER_ELEMENT = "dataPublisher";
     public static final String TOPOLOGY_SYNC_ELEMENT = "topologySync";
     public static final String ENABLE_ATTR = "enable";
@@ -87,27 +46,20 @@ public final class CloudControllerConstants {
     public static final String BAM_SERVER_ADMIN_USERNAME_ELEMENT = "adminUserName";
     public static final String BAM_SERVER_ADMIN_PASSWORD_ELEMENT = "adminPassword";
     public static final String CASSANDRA_INFO_ELEMENT = "cassandraInfo";
-    public static final String HOST_ELEMENT = "host";
     public static final String CONNECTION_URL_ELEMENT = "connectionUrl";
-    public static final String HOST_PORT_ELEMENT = "port";
     public static final String USER_NAME_ELEMENT = "userName";
     public static final String PASSWORD_ELEMENT = "password";
     public static final String CLOUD_CONTROLLER_EVENT_STREAM = "org.apache.stratos.cloud.controller";
-    public static final String CLOUD_CONTROLLER_COL_FAMILY = CLOUD_CONTROLLER_EVENT_STREAM
-            .replaceAll("[/.]", "_");
 
     /**
      * column names
      */
-    public static final String PAYLOAD_PREFIX = "payload_";
     public static final String MEMBER_ID_COL = "memberId";
     public static final String CARTRIDGE_TYPE_COL = "cartridgeType";
     public static final String CLUSTER_ID_COL = "clusterId";
     public static final String CLUSTER_INSTANCE_ID_COL = "clusterInstanceId";
     public static final String PARTITION_ID_COL = "partitionId";
     public static final String NETWORK_ID_COL = "networkId";
-    public static final String ALIAS_COL = "alias";
-    public static final String TENANT_RANGE_COL = "tenantRange";
     public static final String IS_MULTI_TENANT_COL = "isMultiTenant";
     public static final String IAAS_COL = "iaas";
     public static final String STATUS_COL = "status";
@@ -131,17 +83,8 @@ public final class CloudControllerConstants {
      * Properties
      */
     public static final String REGION_PROPERTY = "region";
-    public static final String TOPICS_PROPERTY = "topics";
-    public static final String PUBLIC_IP_PROPERTY = "public_ip";
-    public static final String TENANT_ID_PROPERTY = "tenant_id";
-    public static final String ALIAS_PROPERTY = "alias";
     public static final String AUTO_ASSIGN_IP_PROPERTY = "autoAssignIp";
     public static final String JCLOUDS_ENDPOINT = "jclouds.endpoint";
-    public static final String CRON_PROPERTY = "cron";
-    public static final String AMQP_CONNECTION_URL_PROPERTY = "amqpConnectionUrl";
-    public static final String AMQP_INITIAL_CONTEXT_FACTORY_PROPERTY = "amqpInitialContextFactory";
-    public static final String AMQP_TOPIC_CONNECTION_FACTORY_PROPERTY = "amqpTopicConnectionFactory";
-    public static final String INSTANCE_TOPIC = "instance/*";
     // pre define a floating ip
     public static final String FLOATING_IP_PROPERTY = "floatingIp";
     public static final String DEFAULT_FLOATING_IP_POOL = "defaultFloatingIpPool";
@@ -154,63 +97,14 @@ public final class CloudControllerConstants {
     public static final String IAAS_PROVIDER_XPATH = "/"
             + CLOUD_CONTROLLER_ELEMENT + "/" + IAAS_PROVIDERS_ELEMENT + "/"
             + IAAS_PROVIDER_ELEMENT;
-    public static final String PARTITION_XPATH = "/" + CLOUD_CONTROLLER_ELEMENT
-            + "/" + PARTITIONS_ELEMENT + "/" + PARTITION_ELEMENT;
-    public static final String REGION_XPATH = "/" + CLOUD_CONTROLLER_ELEMENT
-            + "/" + IAAS_PROVIDERS_ELEMENT + "/" + IAAS_PROVIDER_ELEMENT + "/"
-            + REGION_ELEMENT;
-    public static final String ZONE_XPATH = "/" + CLOUD_CONTROLLER_ELEMENT
-            + "/" + IAAS_PROVIDERS_ELEMENT + "/" + IAAS_PROVIDER_ELEMENT + "/"
-            + REGION_ELEMENT + "/" + ZONE_ELEMENT;
-    public static final String HOST_XPATH = "/" + CLOUD_CONTROLLER_ELEMENT
-            + "/" + IAAS_PROVIDERS_ELEMENT + "/" + IAAS_PROVIDER_ELEMENT + "/"
-            + REGION_ELEMENT + "/" + ZONE_ELEMENT + "/" + HOST_ELEMENT;
-    public static final String PROPERTY_ELEMENT_XPATH = "/" + PROPERTY_ELEMENT;
-    public static final String IMAGE_ID_ELEMENT_XPATH = "/" + IMAGE_ID_ELEMENT;
-    public static final String SCALE_UP_ORDER_ELEMENT_XPATH = "/"
-            + SCALE_UP_ORDER_ELEMENT;
-    public static final String SCALE_DOWN_ORDER_ELEMENT_XPATH = "/"
-            + SCALE_DOWN_ORDER_ELEMENT;
-    public static final String PROVIDER_ELEMENT_XPATH = "/" + PROPERTY_ELEMENT;
-    public static final String IDENTITY_ELEMENT_XPATH = "/" + IDENTITY_ELEMENT;
-    public static final String CREDENTIAL_ELEMENT_XPATH = "/"
-            + CREDENTIAL_ELEMENT;
-    public static final String SERVICES_ELEMENT_XPATH = "/" + SERVICES_ELEMENT
-            + "/" + SERVICE_ELEMENT;
-    public static final String SERVICE_ELEMENT_XPATH = "/" + SERVICE_ELEMENT;
-    public static final String CARTRIDGE_ELEMENT_XPATH = "/"
-            + CARTRIDGE_ELEMENT;
-    public static final String PAYLOAD_ELEMENT_XPATH = "/" + PAYLOAD_ELEMENT;
-    public static final String HOST_ELEMENT_XPATH = "/" + HOST_ELEMENT;
-    public static final String CARTRIDGES_ELEMENT_XPATH = "/"
-            + CARTRIDGES_ELEMENT + "/" + CARTRIDGE_ELEMENT;
     public static final String IAAS_PROVIDER_ELEMENT_XPATH = "/"
             + IAAS_PROVIDER_ELEMENT;
-    public static final String DEPLOYMENT_ELEMENT_XPATH = "/"
-            + DEPLOYMENT_ELEMENT;
-    public static final String PORT_MAPPING_ELEMENT_XPATH = "/"
-            + PORT_MAPPING_ELEMENT;
-    public static final String APP_TYPES_ELEMENT_XPATH = "/"
-            + APP_TYPES_ELEMENT;
+
 
     public static final String DATA_PUBLISHER_XPATH = "/"
             + CLOUD_CONTROLLER_ELEMENT + "/" + DATA_PUBLISHER_ELEMENT;
     public static final String TOPOLOGY_SYNC_XPATH = "/"
             + CLOUD_CONTROLLER_ELEMENT + "/" + TOPOLOGY_SYNC_ELEMENT;
-    public static final String DATA_PUBLISHER_CRON_XPATH = "/"
-            + CLOUD_CONTROLLER_ELEMENT + "/" + CRON_ELEMENT;
-    public static final String BAM_SERVER_ADMIN_USERNAME_XPATH = "/"
-            + CLOUD_CONTROLLER_ELEMENT + "/"
-            + BAM_SERVER_ADMIN_USERNAME_ELEMENT;
-    public static final String BAM_SERVER_ADMIN_PASSWORD_XPATH = "/"
-            + CLOUD_CONTROLLER_ELEMENT + "/"
-            + BAM_SERVER_ADMIN_PASSWORD_ELEMENT;
-    // public static final String CASSANDRA_HOST_ADDRESS_XPATH =
-    // "/"+CLOUD_CONTROLLER_ELEMENT+
-    // "/"+CASSANDRA_HOST_ADDRESS;
-    // public static final String CASSANDRA_HOST_PORT_XPATH =
-    // "/"+CLOUD_CONTROLLER_ELEMENT+
-    // "/"+CASSANDRA_HOST_PORT;
 
     /**
      * Secret Manager related aliases.
@@ -222,13 +116,11 @@ public final class CloudControllerConstants {
     /**
      * Payload related constants
      */
-    public static final String PAYLOAD_NAME = "payload";
     public static final String ENTRY_SEPARATOR = ",";
 
     /**
      * Publisher task related constants
      */
-    public static final String DATA_PUB_TASK_TYPE = "CLOUD_CONTROLLER_DATA_PUBLISHER_TASK";
     // default is : data publisher will run in first second of every minute
     public static final String PUB_CRON_EXPRESSION = "1 * * * * ? *";
     public static final String DATA_PUB_TASK_NAME = "CartridgeInstanceDataPublisher";
@@ -237,28 +129,7 @@ public final class CloudControllerConstants {
     public static final String DEFAULT_CASSANDRA_URL = "localhost:9160";
     public static final String DEFAULT_CASSANDRA_USER = "admin";
     public static final String DEFAULT_CASSANDRA_PASSWORD = "admin";
-    public static final String DEFAULT_CASSANDRA_CLUSTER_NAME = "Test Cluster";
-    public static final String DEFAULT_CASSANDRA_KEY_SPACE = "EVENT_KS";
 
-    /**
-     * Directories
-     */
-    public static final String SERVICES_DIR = CarbonUtils.getCarbonRepository()
-            + File.separator + "services" + File.separator;
-
-    /**
-     * Topology sync related constants
-     */
-    public static final String TOPOLOGY_FILE_PATH = CarbonUtils
-            .getCarbonConfigDirPath()
-            + File.separator
-            + "service-topology.conf";
-    public static final String TOPOLOGY_SYNC_CRON = "1 * * * * ? *";
-    public static final String TOPOLOGY_SYNC_TASK_NAME = "TOPOLOGY_SYNC_TASK";
-    public static final String TOPOLOGY_SYNC_TASK_TYPE = "TOPOLOGY_SYNC_TASK_TYPE";
-    public static final String AMQP_CONNECTION_URL = "amqp://admin:admin@clientID/carbon?brokerlist='tcp://localhost:5672'";
-    public static final String AMQP_INITIAL_CONTEXT_FACTORY = "org.wso2.andes.jndi.PropertiesFileInitialContextFactory";
-    public static final String AMQP_TOPIC_CONNECTION_FACTORY = "qpidConnectionfactory";
 
     /**
      * Persistence
@@ -267,7 +138,6 @@ public final class CloudControllerConstants {
     public static final String TOPOLOGY_RESOURCE = "/cloud.controller/topology";
     public static final String AVAILABILITY_ZONE = "availabilityZone";
     public static final String KEY_PAIR = "keyPair";
-    public static final String HOST = "host";
     public static final String SECURITY_GROUP_IDS = "securityGroupIds";
     public static final String SECURITY_GROUPS = "securityGroups";
     public static final String SUBNET_ID = "subnetId";
@@ -278,10 +148,6 @@ public final class CloudControllerConstants {
     public static final String INSTANCE_TYPE = "instanceType";
     public static final String ASSOCIATE_PUBLIC_IP_ADDRESS = "associatePublicIpAddress";
     public static final String LB_CLUSTER_ID_COL = "lbclusterId";
-    public static final String NETWORK_INTERFACES = "networkInterfaces";
-    public static final String NETWORK_FIXED_IP = "fixedIp";
-    public static final String NETWORK_PORT = "portUuid";
-    public static final String NETWORK_UUID = "networkUuid";
 
     // CloudStack specific
     public static final String USER_NAME = "username";
@@ -289,15 +155,11 @@ public final class CloudControllerConstants {
     public static final String DISK_OFFERING = "diskOffering";
     public static final String NETWORK_IDS = "networkIds";
 
-    public static final String IS_LOAD_BALANCER = "load.balancer";
-
     /**
      * PortRange min max
      */
     public static final int PORT_RANGE_MAX = 65535;
     public static final int PORT_RANGE_MIN = 1;
-
-    public static final String KUBERNETES_PARTITION_PROVIDER = "kubernetes";
 
     /**
      * Load balancing ip type enumeration values

--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/util/CloudControllerUtil.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/util/CloudControllerUtil.java
@@ -20,7 +20,6 @@ package org.apache.stratos.cloud.controller.util;
 
 import com.google.common.net.InetAddresses;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.stratos.cloud.controller.config.CloudControllerConfig;
@@ -188,17 +187,6 @@ public class CloudControllerUtil {
         return getProperty(props, key);
     }
 
-    public static org.apache.stratos.common.Properties addProperty(org.apache.stratos.common.Properties properties,
-                                                                   String key, String value) {
-        Property property = new Property();
-        property.setName(key);
-        property.setValue(value);
-
-        org.apache.stratos.common.Properties newProperties = new org.apache.stratos.common.Properties();
-        newProperties.setProperties(ArrayUtils.add(properties.getProperties(), property));
-        return newProperties;
-    }
-
     /**
      * Converts org.apache.stratos.messaging.util.Properties to java.util.Properties
      *
@@ -349,15 +337,6 @@ public class CloudControllerUtil {
         } catch (InvalidKubernetesHostException e) {
             throw new InvalidKubernetesMasterException(e.getMessage());
         }
-    }
-
-    public static String getLoadBalancingIPTypeStringFromEnum(LoadBalancingIPType loadBalancingIPType) {
-        if (loadBalancingIPType == LoadBalancingIPType.Private) {
-            return CloudControllerConstants.LOADBALANCING_IP_TYPE_PRIVATE;
-        } else if (loadBalancingIPType == LoadBalancingIPType.Public) {
-            return CloudControllerConstants.LOADBALANCING_IP_TYPE_PUBLIC;
-        }
-        return null;
     }
 
     public static LoadBalancingIPType getLoadBalancingIPTypeEnumFromString(String loadBalancingIPType) {


### PR DESCRIPTION
This P/R includes cleaning and formatting some classes in Cloud-Controller. Following changes are included:

1. Fix for SonarQube Analysis issues:
remove unused imports and variables - CloudControllerConfig
modifier public, abstract is redundant for interface methods - PartitionValidator
removing unused constants - CloudControllerConstants
adding param tag - CloudControllerServiceUtil
local variable isValid is redundant - CloudControllerServiceUtil
local variable iaas is redundant - CloudControllerUtil
for loop replaceable with foreach loop - CloudControllerUtil
removing unused methods - CloudControllerUtil
String concatenation as argument to StringBuilder.append() call - CloudControllerUtil
removing unused variable context - CloudControllerUtil
removing unused methods - CloudControllerUtil

2. Formatting code.