### PR TITLE
Removing duplicate sendMemberActivatedEvent() call

### DIFF
--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
@@ -631,8 +631,6 @@ public class TopologyBuilder {
                 memberActivatedEvent.setMemberPublicIPs(member.getMemberPublicIPs());
                 TopologyManager.updateTopology(topology);
 
-                // Publish member activated event
-                TopologyEventPublisher.sendMemberActivatedEvent(memberActivatedEvent);
                 //member activated time
                 Long timestamp = System.currentTimeMillis();
                 // Publish member activated event


### PR DESCRIPTION
This p/r is to remove duplicate sendMemberActivatedEvent() call.