### PR TITLE
Adding license header to aws.properties file

### DIFF
--- a/extensions/load-balancer/modules/aws-extension/src/main/conf/aws.properties
+++ b/extensions/load-balancer/modules/aws-extension/src/main/conf/aws.properties
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 access-key=
 secret-key=
 # load-balancer-prefix should contain only alphabets and dashes and should not exceed 25 characters.


### PR DESCRIPTION
This p/r is to add license header to aws.properties file in aws loadbalancer extension.