### PR TITLE
implementing STRATOS-1628

### DIFF
--- a/components/org.apache.stratos.mock.iaas.api/src/main/java/org/apache/stratos/mock/iaas/api/MockIaasApi.java
+++ b/components/org.apache.stratos.mock.iaas.api/src/main/java/org/apache/stratos/mock/iaas/api/MockIaasApi.java
@@ -52,7 +52,7 @@ public class MockIaasApi {
     }
 
     @GET
-    @Path("/init")
+    @Path("/status")
     @Produces("application/json")
     public Response init() throws MockIaasApiException {
 

--- a/components/org.apache.stratos.mock.iaas.api/src/main/java/org/apache/stratos/mock/iaas/api/MockIaasApi.java
+++ b/components/org.apache.stratos.mock.iaas.api/src/main/java/org/apache/stratos/mock/iaas/api/MockIaasApi.java
@@ -21,6 +21,8 @@ package org.apache.stratos.mock.iaas.api;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.stratos.common.Component;
+import org.apache.stratos.common.services.ComponentStartUpSynchronizer;
 import org.apache.stratos.mock.iaas.api.exception.MockIaasApiException;
 import org.apache.stratos.mock.iaas.config.MockIaasConfig;
 import org.apache.stratos.mock.iaas.domain.MockInstanceContext;
@@ -47,6 +49,24 @@ public class MockIaasApi {
     private MockIaasService mockIaasService;
 
     public MockIaasApi() {
+    }
+
+    @GET
+    @Path("/init")
+    @Produces("application/json")
+    public Response init() throws MockIaasApiException {
+
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        Object serviceObj = carbonContext.getOSGiService(ComponentStartUpSynchronizer.class);
+        if (serviceObj == null || !(serviceObj instanceof ComponentStartUpSynchronizer)) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+
+        ComponentStartUpSynchronizer componentStartUpSynchronizer = (ComponentStartUpSynchronizer) serviceObj;
+        if (!componentStartUpSynchronizer.isComponentActive(Component.MockIaaS)) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+        }
+        return Response.status(Response.Status.OK).build();
     }
 
     @POST

--- a/components/org.apache.stratos.mock.iaas.client/src/main/java/org/apache/stratos/mock/iaas/client/MockIaasApiClient.java
+++ b/components/org.apache.stratos.mock.iaas.client/src/main/java/org/apache/stratos/mock/iaas/client/MockIaasApiClient.java
@@ -39,7 +39,7 @@ public class MockIaasApiClient {
 
     private static final Log log = LogFactory.getLog(MockIaasApiClient.class);
     private static final String INSTANCES_CONTEXT = "/instances/";
-    private static final String INIT_CONTEXT = "/init";
+    private static final String INIT_CONTEXT = "/status";
 
     private RestClient restClient;
     private String endpoint;
@@ -53,10 +53,7 @@ public class MockIaasApiClient {
         try {
             URI uri = new URIBuilder(endpoint + INIT_CONTEXT).build();
             HttpResponse response = restClient.doGet(uri);
-            if (response != null) {
-                return response.getStatusCode() == 200;
-            }
-            throw new RuntimeException("An unknown error occurred");
+            return response != null && response.getStatusCode() == 200;
         } catch (Exception e) {
             String message = "Could not check whether mock-iaas is active";
             throw new RuntimeException(message, e);

--- a/components/org.apache.stratos.mock.iaas.client/src/main/java/org/apache/stratos/mock/iaas/client/MockIaasApiClient.java
+++ b/components/org.apache.stratos.mock.iaas.client/src/main/java/org/apache/stratos/mock/iaas/client/MockIaasApiClient.java
@@ -39,6 +39,7 @@ public class MockIaasApiClient {
 
     private static final Log log = LogFactory.getLog(MockIaasApiClient.class);
     private static final String INSTANCES_CONTEXT = "/instances/";
+    private static final String INIT_CONTEXT = "/init";
 
     private RestClient restClient;
     private String endpoint;
@@ -46,6 +47,20 @@ public class MockIaasApiClient {
     public MockIaasApiClient(String endpoint) {
         this.restClient = new RestClient();
         this.endpoint = endpoint;
+    }
+
+    public boolean isMockIaaSReady() {
+        try {
+            URI uri = new URIBuilder(endpoint + INIT_CONTEXT).build();
+            HttpResponse response = restClient.doGet(uri);
+            if (response != null) {
+                return response.getStatusCode() == 200;
+            }
+            throw new RuntimeException("An unknown error occurred");
+        } catch (Exception e) {
+            String message = "Could not check whether mock-iaas is active";
+            throw new RuntimeException(message, e);
+        }
     }
 
     public MockInstanceMetadata startInstance(MockInstanceContext mockInstanceContext) {


### PR DESCRIPTION
Currently, integrations test is looking at specific log messages to determine whether the stratos server is ready to handle request or not. Proper way would be to check with an API whether the server is ready or not. This PR is to implement this check in the following way.  

a) exposing an API in mock API to check whether mock iaas is activated or not.
b) integration tests should be started after getting a positive response from the above API.

As per our component start up order, the above solution will make sure that every component is ready to handle requests.
