### PR TITLE
Removing Member Information Publisher not enabled warn log

### DIFF
--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
@@ -444,8 +444,6 @@ public class TopologyBuilder {
                             .getProperty(StratosConstants.SCALING_DECISION_ID).getValue();
                     memInfoPublisher.publish(memberContext.getMemberId(), scalingDecisionId,
                             memberContext.getInstanceMetadata());
-                } else {
-                    log.warn("Member information publisher is not enabled");
                 }
                 if (memStatusPublisher.isEnabled()) {
                     if (log.isInfoEnabled()) {


### PR DESCRIPTION
This p/r is to remove "Member information publisher not enabled" warn log.