### PR TITLE
Fixing line spaces added

### DIFF
--- a/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
+++ b/components/org.apache.stratos.cloud.controller/src/main/java/org/apache/stratos/cloud/controller/messaging/topology/TopologyBuilder.java
@@ -415,7 +415,6 @@ public class TopologyBuilder {
                 log.error("Invalid state transition from " + member.getStatus() + " to " +
                         MemberStatus.Initialized);
             } else {
-
                 Cluster cluster = service.getCluster(memberContext.getClusterId());
                 String clusterId = cluster.getClusterId();
                 ClusterContext clusterContext = CloudControllerContext.getInstance().getClusterContext(clusterId);

--- a/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
+++ b/components/org.apache.stratos.rest.endpoint/src/main/java/org/apache/stratos/rest/endpoint/api/StratosApiV41Utils.java
@@ -1578,8 +1578,6 @@ public class StratosApiV41Utils {
                 if (group.getCartridges() != null) {
                     if (group.getDeploymentPolicy() != null) {
                         groupParentHasDeploymentPolicy = true;
-                    } else {
-                        groupParentHasDeploymentPolicy = false;
                     }
                     validateCartridgesForDeploymentPolicy(group.getCartridges(), groupParentHasDeploymentPolicy);
                 }
@@ -1610,9 +1608,9 @@ public class StratosApiV41Utils {
      * @throws RestAPIException
      */
     private static void validateCartridgesForDeploymentPolicy(List<CartridgeReferenceBean> cartridgeReferenceBeans,
-            boolean hasDeploymentPolicy) throws RestAPIException {
+            boolean groupParentHasDeploymentPolicy) throws RestAPIException {
 
-        if (hasDeploymentPolicy) {
+        if (groupParentHasDeploymentPolicy) {
             for (CartridgeReferenceBean cartridge : cartridgeReferenceBeans) {
                 if (cartridge.getSubscribableInfo().getDeploymentPolicy() != null) {
                     String message = "Group deployment policy already exists. Remove deployment policy from " +


### PR DESCRIPTION
Fixed line space added in a method.
Renamed hasDP to groupParentHasDeploymentPolicy
simplified the logic in group validation 